### PR TITLE
Allow environment variables as a default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "lts/*"
+  - "8"
+  - "9"
+  - "10"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mux Node SDK
 
+![build status](https://api.travis-ci.org/muxinc/mux-node-sdk.svg?branch=master)
+
 Official Mux API wrapper for Node projects.
 
 This library is intended to provide Mux API convenience methods for applications written in server-side Javascript. __Please note__ that this package uses Mux access tokens and secret keys and is intended to be used in server-side code only.

--- a/src/base.js
+++ b/src/base.js
@@ -1,0 +1,53 @@
+class Base {
+  constructor(...params) {
+    if (params[0] instanceof Base) {
+      this.tokenId = params[0].tokenId;
+      this.tokenSecret = params[0].tokenSecret;
+      return this;
+    } else {
+      this.tokenId = params[0] || process.env.MUX_TOKEN_ID;
+      this.tokenSecret = params[1] || process.env.MUX_TOKEN_SECRET;
+    }
+  }
+
+  set tokenId (token) {
+    this._tokenId = token;
+
+    if (typeof this._tokenId === 'undefined') {
+      throw new Error('API Access Token must be provided.');
+    }
+  }
+
+  get tokenId () {
+    return this._tokenId;
+  }
+
+  set tokenSecret (secret) {
+    this._secret = secret;
+
+    if (typeof this._secret === 'undefined' || this._secret === '') {
+      throw new Error('API secret key must be provided');
+    }
+  }
+
+  get tokenSecret () {
+    return this._secret;
+  }
+
+  /**
+   *  @ignore
+   *  @type {Object} requestOptions - The HTTP request options for Mux Assets
+   *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
+   *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
+   * */
+  get requestOptions () {
+    return {
+      auth: {
+        username: this.tokenId,
+        password: this.tokenSecret,
+      }
+    }
+  }
+}
+
+module.exports = Base;

--- a/src/base.js
+++ b/src/base.js
@@ -1,16 +1,28 @@
+/* eslint no-underscore-dangle: ["error", { "allow": ["_tokenId", "_secret"] }] */
+
+/**
+ * Mux Base Class - Simple base class to be extended by all child modules.
+ *
+ * @property {string} tokenId - The ID for the access token.
+ * @property {string} tokenSecret - The secret for the access token.
+ * @property {Object} requestOptions - The HTTP request options for Mux Assets
+ * @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
+ * @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
+ *
+ */
 class Base {
   constructor(...params) {
-    if (params[0] instanceof Base) {
+    if (params[0] && params[0].tokenId) {
       this.tokenId = params[0].tokenId;
       this.tokenSecret = params[0].tokenSecret;
       return this;
-    } else {
-      this.tokenId = params[0] || process.env.MUX_TOKEN_ID;
-      this.tokenSecret = params[1] || process.env.MUX_TOKEN_SECRET;
     }
+
+    this.tokenId = params[0] || process.env.MUX_TOKEN_ID;
+    this.tokenSecret = params[1] || process.env.MUX_TOKEN_SECRET;
   }
 
-  set tokenId (token) {
+  set tokenId(token) {
     this._tokenId = token;
 
     if (typeof this._tokenId === 'undefined') {
@@ -18,11 +30,11 @@ class Base {
     }
   }
 
-  get tokenId () {
+  get tokenId() {
     return this._tokenId;
   }
 
-  set tokenSecret (secret) {
+  set tokenSecret(secret) {
     this._secret = secret;
 
     if (typeof this._secret === 'undefined' || this._secret === '') {
@@ -30,17 +42,11 @@ class Base {
     }
   }
 
-  get tokenSecret () {
+  get tokenSecret() {
     return this._secret;
   }
 
-  /**
-   *  @ignore
-   *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-   *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-   *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-   * */
-  get requestOptions () {
+  get requestOptions() {
     return {
       auth: {
         username: this.tokenId,

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -12,6 +12,7 @@ const VideoViews = require('../../src/data/resources/video_views');
 
 /**
  * @ignore
+ * @extends Base
  * Data Class - Provides access to the Mux Data API
  *
  * @example

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -3,6 +3,7 @@
  * Copyright(c) 2018 Mux Inc.
  */
 
+const Base = require('../base');
 const Metrics = require('../../src/data/resources/metrics');
 const Errors = require('../../src/data/resources/errors');
 const Filters = require('../../src/data/resources/filters');
@@ -18,7 +19,7 @@ const VideoViews = require('../../src/data/resources/video_views');
  * const { Data } = muxClient;
  *
  */
-class Data {
+class Data extends Base {
   /**
    * Data Constructor
    *
@@ -26,29 +27,23 @@ class Data {
    * @param {string} secret - Mux API secret
    * @constructor
    */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
+  constructor(...params) {
+    super(...params);
 
     /** @type {Metrics} */
-    this.metrics = new Metrics(accessToken, secret);
+    this.metrics = new Metrics(this);
 
     /** @type {Errors} */
-    this.errors = new Errors(accessToken, secret);
+    this.errors = new Errors(this);
 
     /** @type {Filters} */
-    this.filters = new Filters(accessToken, secret);
+    this.filters = new Filters(this);
 
     /** @type {Exports} */
-    this.exports = new Exports(accessToken, secret);
+    this.exports = new Exports(this);
 
     /** @type {VideoViews} */
-    this.videoViews = new VideoViews(accessToken, secret);
+    this.videoViews = new VideoViews(this);
   }
 }
 

--- a/src/data/resources/errors.js
+++ b/src/data/resources/errors.js
@@ -13,7 +13,7 @@ const PATH = '/data/v1/errors';
 
 /**
  * Errors Class - Provides access to the Mux Data Errors API
- *
+ * @extends Base
  * @example
  * const muxClient = new Mux(accessToken, secret);
  * const { Data } = muxClient;

--- a/src/data/resources/errors.js
+++ b/src/data/resources/errors.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private Base errors path for the Mux API
@@ -20,38 +21,7 @@ const PATH = '/data/v1/errors';
  * // Returns a list of playback errors filtered by the windows operating system
  * Data.errors.list({ filters: ['operating_system:windows'] });
  */
-class Errors {
-  /**
-   * @ignore
-   * Errors Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class Errors extends Base {
   /**
    * Returns a list of playback errors
    *

--- a/src/data/resources/exports.js
+++ b/src/data/resources/exports.js
@@ -24,6 +24,7 @@ const PATH = '/data/v1/exports';
 class Exports extends Base {
   /**
    * Lists the available video view exports along with URLs to retrieve them
+   * @extends Base
    * @returns {Promise} - Returns a resolved Promise with a response from the Mux API
    *
    * @example

--- a/src/data/resources/exports.js
+++ b/src/data/resources/exports.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private Base exports path for the Mux API
@@ -20,38 +21,7 @@ const PATH = '/data/v1/exports';
  * // Lists the available video view exports along with URLs to retrieve them
  * Data.exports.list();
  */
-class Exports {
-  /**
-   * @ignore
-   * Exports Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class Exports extends Base {
   /**
    * Lists the available video view exports along with URLs to retrieve them
    * @returns {Promise} - Returns a resolved Promise with a response from the Mux API

--- a/src/data/resources/filters.js
+++ b/src/data/resources/filters.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private Base filters path for the Mux API
@@ -20,38 +21,7 @@ const PATH = '/data/v1/filters';
  * // Lists all the filters broken out into basic and advanced
  * Data.filters.list();
  */
-class Filters {
-  /**
-   * @ignore
-   * Filters Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class Filters extends Base {
   /**
    * Lists the values for a filter along with a total count of related views
    *

--- a/src/data/resources/filters.js
+++ b/src/data/resources/filters.js
@@ -14,6 +14,7 @@ const PATH = '/data/v1/filters';
 /**
  * Filters Class - Provides access to the Mux Data Filters API
  *
+ * @extends Base
  * @example
  * const muxClient = new Mux(accessToken, secret);
  * const { Data } = muxClient;

--- a/src/data/resources/metrics.js
+++ b/src/data/resources/metrics.js
@@ -14,6 +14,7 @@ const PATH = '/data/v1/metrics';
 /**
  * Metrics Class - Provides access to the Mux Data Metrics API
  *
+ * @extends Base
  * @example
  * const muxClient = new Mux(accessToken, secret);
  * const { Data } = muxClient;

--- a/src/data/resources/metrics.js
+++ b/src/data/resources/metrics.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private Base metrics path for the Mux API
@@ -20,38 +21,7 @@ const PATH = '/data/v1/metrics';
  * // List all of the values across every breakdown for a specific metric grouped by operating system
  * Data.metrics.breakdown('aggregate_startup_time', { group_by: 'operating_system' });
  */
-class Metrics {
-  /**
-   * @ignore
-   * Metrics Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class Metrics extends Base {
   /**
    * List the breakdown values for a specific metric
    *

--- a/src/data/resources/video_views.js
+++ b/src/data/resources/video_views.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private Base exports path for the Mux API
@@ -21,38 +22,7 @@ const PATH = '/data/v1/video-views';
  * // Results are ordered by view_end, according to what you provide for order_direction.
  * Data.videoViews.list({order_direction: 'asc'});
  */
-class VideoViews {
-  /**
-   * @ignore
-   * VideoViews Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class VideoViews extends Base {
   /**
    * Returns a list of video views for a property that occurred within the specified timeframe.
    * Results are ordered by view_end, according to what you provide for order_direction.

--- a/src/data/resources/video_views.js
+++ b/src/data/resources/video_views.js
@@ -27,6 +27,7 @@ class VideoViews extends Base {
    * Returns a list of video views for a property that occurred within the specified timeframe.
    * Results are ordered by view_end, according to what you provide for order_direction.
    *
+   * @extends Base
    * @param {Object} queryParams - example { viewer_id: 'ABCD1234', timeframe: ['7:days'], filters: ['operating_system:windows'] }
    * NOTE: the viewer_id query parameter is required
    * @returns {Promise} - Returns a resolved Promise with a response from the Mux API

--- a/src/mux.js
+++ b/src/mux.js
@@ -3,6 +3,7 @@
  * Copyright(c) 2018 Mux Inc.
  */
 
+const Base = require('./base');
 const Video = require('./video/video');
 const Data = require('./data/data');
 
@@ -31,7 +32,7 @@ const Data = require('./data/data');
  * // List all of the values across every breakdown for the `aggregate_startup_time` metric
  * Data.metrics.breakdown('aggregate_startup_time', { group_by: 'browser' });
  */
-class Mux {
+class Mux extends Base {
   /**
    * Mux Constructor
    *
@@ -40,19 +41,13 @@ class Mux {
    * @constructor
    */
   constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
+    super(accessToken, secret);
 
     /** @type {Video} */
-    this.Video = new Video(accessToken, secret);
+    this.Video = new Video(this);
 
     /** @type {Data} */
-    this.Data = new Data(accessToken, secret);
+    this.Data = new Data(this);
   }
 }
 

--- a/src/mux.js
+++ b/src/mux.js
@@ -10,6 +10,7 @@ const Data = require('./data/data');
 /**
  * Mux Class - Provides access to the Mux Video and Mux Data API
  *
+ * @extends Base
  * @type {Video}
  * @property {Video} Mux.Video provides access to the Mux Video API
  * @type {Data}

--- a/src/video/resources/assets.js
+++ b/src/video/resources/assets.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private Base asset path for the Mux API
@@ -26,38 +27,7 @@ const buildBasePath = assetId => `${PATH}/${assetId}`;
  * // Create an asset
  * Video.assets.create({input: 'https://storage.googleapis.com/muxdemofiles/mux-video-intro.mp4'});
  */
-class Assets {
-  /**
-   * @ignore
-   * Assets Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class Assets extends Base {
   /**
    * Creates a Mux asset with the specified JSON parameters
    * @param {Object} params - Asset JSON parameters (e.g input)

--- a/src/video/resources/assets.js
+++ b/src/video/resources/assets.js
@@ -30,6 +30,7 @@ const buildBasePath = assetId => `${PATH}/${assetId}`;
 class Assets extends Base {
   /**
    * Creates a Mux asset with the specified JSON parameters
+   * @extends Base
    * @param {Object} params - Asset JSON parameters (e.g input)
    * @returns {Promise} - Returns a resolved Promise with a response from the Mux API
    *

--- a/src/video/resources/liveStreams.js
+++ b/src/video/resources/liveStreams.js
@@ -20,6 +20,7 @@ const buildBasePath = liveStreamId => `${PATH}/${liveStreamId}`;
 /**
  * Live Streams Class - Provides access to the Mux Video Live Streams API
  *
+ * @extends Base
  * @example
  * const muxClient = new Mux(accessToken, secret);
  * const { Video } = muxClient;

--- a/src/video/resources/liveStreams.js
+++ b/src/video/resources/liveStreams.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private Base live stream path for the Mux API
@@ -26,38 +27,7 @@ const buildBasePath = liveStreamId => `${PATH}/${liveStreamId}`;
  * // Create a live stream
  * Video.liveStreams.create({ playback_policy: 'public', new_asset_settings: { playback_policy: 'public' } });
  */
-class LiveStreams {
-  /**
-   * @ignore
-   * LiveStreams Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Live Streams
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class LiveStreams extends Base {
   /**
    * Creates a Mux live stream with the specified JSON parameters
    * @param {Object} params - Live Stream JSON parameters (e.g playback_policy)

--- a/src/video/resources/playbackIds.js
+++ b/src/video/resources/playbackIds.js
@@ -4,6 +4,7 @@
  */
 
 const api = require('../../utils/api');
+const Base = require('../../base');
 
 /**
  * @private
@@ -21,38 +22,7 @@ const buildBasePath = assetId => `/video/v1/assets/${assetId}/playback-ids`;
  * // Create a playback Id for an asset
  * Video.playbackIds.create('assetId', { policy: 'public' });
  */
-class PlaybackIds {
-  /**
-   * @ignore
-   * PlaybackIds Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API Access Token secret
-   * @constructor
-   */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
-
-    /**
-     *  @ignore
-     *  @type {Object} requestOptions - The HTTP request options for Mux Assets
-     *  @property {string} requestOptions.auth.username - HTTP basic auth username (access token)
-     *  @property {string} requestOptions.auth.password - HTTP basic auth password (secret)
-     * */
-    this.requestOptions = {
-      auth: {
-        username: accessToken,
-        password: secret,
-      },
-    };
-  }
-
+class PlaybackIds extends Base {
   /**
    * Creates a playback ID for a Mux asset with the specified JSON parameters
    * @param {string} assetId - Asset ID for the asset to create the playback ID for

--- a/src/video/resources/playbackIds.js
+++ b/src/video/resources/playbackIds.js
@@ -15,6 +15,7 @@ const buildBasePath = assetId => `/video/v1/assets/${assetId}/playback-ids`;
 /**
  * PlaybackIds Class - Provides access to the Mux Video PlaybackIds API
  *
+ * @extends Base
  * @example
  * const muxClient = new Mux(accessToken, secret);
  * const { Video } = muxClient;

--- a/src/video/video.js
+++ b/src/video/video.js
@@ -4,6 +4,7 @@
  */
 
 const Assets = require('./resources/assets');
+const Base = require('../base');
 const PlaybackIds = require('./resources/playbackIds');
 const LiveStreams = require('./resources/liveStreams');
 
@@ -21,7 +22,7 @@ const LiveStreams = require('./resources/liveStreams');
  * // Create a playback Id for an asset
  * Video.playbackIds.create('assetId', { policy: 'public' });
  */
-class Video {
+class Video extends Base {
   /**
    * Video Constructor
    *
@@ -29,23 +30,17 @@ class Video {
    * @param {string} secret - Mux API secret
    * @constructor
    */
-  constructor(accessToken, secret) {
-    if (typeof accessToken === 'undefined') {
-      throw new Error('API Access Token must be provided.');
-    }
-
-    if (typeof secret === 'undefined') {
-      throw new Error('API secret key must be provided');
-    }
+  constructor(...params) {
+    super(...params);
 
     /** @type {Assets} */
-    this.assets = new Assets(accessToken, secret);
+    this.assets = new Assets(this);
 
     /** @type {PlaybackIds} */
-    this.playbackIds = new PlaybackIds(accessToken, secret);
+    this.playbackIds = new PlaybackIds(this);
 
     /** @type {LiveStreams} */
-    this.liveStreams = new LiveStreams(accessToken, secret);
+    this.liveStreams = new LiveStreams(this);
   }
 }
 

--- a/src/video/video.js
+++ b/src/video/video.js
@@ -10,6 +10,7 @@ const LiveStreams = require('./resources/liveStreams');
 
 /**
  * @ignore
+ * @extends Base
  * Video Class - Provides access to the Mux Video API
  *
  * @example

--- a/test/unit/base.spec.js
+++ b/test/unit/base.spec.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai');
+const Base = require('../../src/base');
+
+/** @test {Mux} */
+describe('Unit::Base', () => {
+  afterEach(() => {
+    process.env.MUX_TOKEN_ID = undefined;
+    process.env.MUX_TOKEN_SECRET = undefined;
+  });
+
+  /** @test {Base} */
+  describe('Base', () => {
+    /** @test {Base} */
+    it('allows configuration to be passed in as params', () => {
+      const baseClient = new Base('testKey', 'testSecret');
+      expect(baseClient.tokenId).to.be.eq('testKey');
+      expect(baseClient.tokenSecret).to.be.eq('testSecret');
+    });
+
+    it('allows configuration to be passed in via environment variables', () => {
+      process.env.MUX_TOKEN_ID = 'testKey';
+      process.env.MUX_TOKEN_SECRET = 'testSecret';
+      const baseClient = new Base();
+      expect(baseClient.tokenId).to.be.eq('testKey');
+      expect(baseClient.tokenSecret).to.be.eq('testSecret');
+    });
+
+    it('prioritizes params over environment variables', () => {
+      process.env.MUX_TOKEN_ID = 'crusty-old-id';
+      process.env.MUX_TOKEN_SECRET = 'crusty-old-secret';
+      const baseClient = new Base('fancy-new-id', 'fancy-new-secret');
+      expect(baseClient.tokenId).to.be.eq('fancy-new-id');
+      expect(baseClient.tokenSecret).to.be.eq('fancy-new-secret');
+    });
+
+    it('allows configuration to be passed in via the parent instance', () => {
+      const parentBase = new Base('testKey', 'testSecret');
+      const childBase = new Base(parentBase);
+      expect(childBase.tokenId).to.be.eq(parentBase.tokenId);
+      expect(childBase.tokenSecret).to.be.eq(parentBase.tokenSecret);
+    });
+
+    it('exposes a requestOptions getter for request authenntication', () => {
+      const baseClient = new Base('testKey', 'testSecret');
+      expect(baseClient.requestOptions).to.be.eql({
+        auth: {
+          username: 'testKey',
+          password: 'testSecret',
+        },
+      });
+    });
+  });
+});

--- a/test/unit/base.spec.js
+++ b/test/unit/base.spec.js
@@ -4,8 +4,8 @@ const Base = require('../../src/base');
 /** @test {Mux} */
 describe('Unit::Base', () => {
   afterEach(() => {
-    process.env.MUX_TOKEN_ID = undefined;
-    process.env.MUX_TOKEN_SECRET = undefined;
+    delete process.env.MUX_TOKEN_ID;
+    delete process.env.MUX_TOKEN_SECRET;
   });
 
   /** @test {Base} */


### PR DESCRIPTION
If you have the two environment variables `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` in your environment variables, you don't need to include them when you create a new class.

Also refactored a bit so I only needed to do this check in one place.