### PR TITLE
Mux Node user agent and allow for an options config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ const Mux = require('@mux/mux-node');
 const muxClient = new Mux(accessToken, secret);
 const { Video, Data } = muxClient;
 ```
+
+If a token ID and secret aren't included as parameters, the SDK will attempt to use the `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` environment variables.
+
 As an example, you can create a Mux asset and playback ID by using the below functions on your Video instance.
 ```javascript
 // Create an asset

--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ that will allow you to access the Mux Data and Video APIs.
 
 ```javascript
 const Mux = require('@mux/mux-node');
-const muxClient = new Mux(accessToken, secret);
-const { Video, Data } = muxClient;
+const { Video, Data } = new Mux(accessToken, secret);
 ```
 
 If a token ID and secret aren't included as parameters, the SDK will attempt to use the `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` environment variables.
+
+```javascript
+// assume process.env.MUX_TOKEN_ID and process.env.MUX_TOKEN_SECRET contain your credentials
+const muxClient = new Mux(); // Success!
+```
 
 As an example, you can create a Mux asset and playback ID by using the below functions on your Video instance.
 ```javascript

--- a/src/base.js
+++ b/src/base.js
@@ -29,9 +29,9 @@ class Base extends EventEmitter {
       this.tokenId = undefined;
       this.tokenSecret = undefined;
     } else {
-      this.config = {};
       this.tokenId = params[0]; // eslint-disable-line prefer-destructuring
       this.tokenSecret = params[1]; // eslint-disable-line prefer-destructuring
+      this.config = params[2]; // eslint-disable-line prefer-destructuring
     }
 
     this.http = axios.create({

--- a/src/mux.js
+++ b/src/mux.js
@@ -40,7 +40,7 @@ class Mux extends Base {
    * @param {string|options} accessToken - Mux API Access Token, or a configuration object.
    * @param {string} secret - Mux API secret
    * @param {object} options - Optional configuration object
-   * @param {object='https://api.mux.com'} options.baseUrl - Change the base URL for API requests.
+   * @param {string='https://api.mux.com'} options.baseUrl - Change the base URL for API requests.
    * @constructor
    */
   constructor(accessTokenOrConfig, secret, config) {

--- a/src/mux.js
+++ b/src/mux.js
@@ -37,7 +37,7 @@ class Mux extends Base {
   /**
    * Mux Constructor
    *
-   * @param {string|options} accessToken - Mux API Access Token, or a configuration object.
+   * @param {string} accessToken - Mux API Access Token
    * @param {string} secret - Mux API secret
    * @param {object} options - Optional configuration object
    * @param {string='https://api.mux.com'} options.baseUrl - Change the base URL for API requests.

--- a/src/mux.js
+++ b/src/mux.js
@@ -37,8 +37,8 @@ class Mux extends Base {
   /**
    * Mux Constructor
    *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API secret
+   * @param {string=process.env.MUX_TOKEN_ID} accessToken - Mux API Access Token
+   * @param {string=process.env.MUX_TOKEN_SECRET} secret - Mux API secret
    * @param {object} options - Optional configuration object
    * @param {string='https://api.mux.com'} options.baseUrl - Change the base URL for API requests.
    * @constructor

--- a/src/mux.js
+++ b/src/mux.js
@@ -37,12 +37,14 @@ class Mux extends Base {
   /**
    * Mux Constructor
    *
-   * @param {string} accessToken - Mux API Access Token
+   * @param {string|options} accessToken - Mux API Access Token, or a configuration object.
    * @param {string} secret - Mux API secret
+   * @param {object} options - Optional configuration object
+   * @param {object='https://api.mux.com'} options.baseUrl - Change the base URL for API requests.
    * @constructor
    */
-  constructor(accessToken, secret) {
-    super(accessToken, secret);
+  constructor(accessTokenOrConfig, secret, config) {
+    super(accessTokenOrConfig, secret, config);
 
     /** @type {Video} */
     this.Video = new Video(this);


### PR DESCRIPTION
- Updates the user agent to be Mux Node and the version number
- Allows a configuration object to be passed into the base to make it easier to adjust the base url for testing, etc.