### PR TITLE
Add Mux.Webhooks.verifyHeader function

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ Video.Assets.create({
 });
 ```
 
+## Verifying Webhook Signatures
+
+[TODO] - add link to docs and explanation of this feature
+
+```javascript
+/*
+  If the header is valid, this will return `true`
+  If invalid, this will throw one of the following errors:
+    * new Error('Unable to extract timestamp and signatures from header')
+    * new Error('No signatures found with expected scheme');
+    * new Error('No signatures found matching the expected signature for payload.')
+    * new Error('Timestamp outside the tolerance zone')
+*/
+
+/*
+  `payload` is the raw request body. It should be a string representation of a JSON object.
+  `header` is the value in request.headers['Mux-Signature']
+  `secret` is the signing secret for this configured webhook. You can find that in your webhooks dashboard
+           (note that this secret is different than your API Secret Key)
+*/
+
+Mux.Webhooks.verifyHeader(payload, header, secret);
+```
+
 ## JWT Helpers <small>([API Reference](https://muxinc.github.io/mux-node-sdk/class/src/utils/jwt.js~JWT.html))</small>
 
 You can use any JWT-compatible library, but we've included some light helpers in the SDK to make it easier to get up and running.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Video.Assets.create({
 
 ## Verifying Webhook Signatures
 
-[TODO] - add link to docs and explanation of this feature
+Learn more about verifying webhook headers in our [Webhooks Security Guide](https://docs.mux.com/docs/webhook-security)
+
 
 ```javascript
 /*

--- a/src/mux.js
+++ b/src/mux.js
@@ -6,6 +6,7 @@
 const Base = require('./base');
 const Video = require('./video/video');
 const Data = require('./data/data');
+const Webhooks = require('./webhooks/webhooks');
 const JWT = require('./utils/jwt');
 
 /**
@@ -16,9 +17,11 @@ const JWT = require('./utils/jwt');
  * @property {Video} Mux.Video provides access to the Mux Video API
  * @type {Data}
  * @property {Data} Mux.Data provides access to the Mux Data API
+ * @type {Webhooks}
+ * @property {Webhooks} Mux.Webhooks provides access to verifying Webhooks signatures
  * @example
  * const muxClient = new Mux(accessToken, secret);
- * const { Video, Data } = muxClient;
+ * const { Video, Data, Webhooks } = muxClient;
  *
  * // Create an asset
  * let assetId;
@@ -33,6 +36,9 @@ const JWT = require('./utils/jwt');
  *
  * // List all of the values across every breakdown for the `aggregate_startup_time` metric
  * Data.metrics.breakdown('aggregate_startup_time', { group_by: 'browser' });
+
+ * // Verify a webhook signature
+ * Webhooks.verifyHeader(body, signature, secret);
  */
 class Mux extends Base {
   /**
@@ -52,6 +58,8 @@ class Mux extends Base {
 
     /** @type {Data} */
     this.Data = new Data(this);
+
+    this.Webhooks = new Webhooks(this);
   }
 }
 

--- a/src/mux.js
+++ b/src/mux.js
@@ -58,8 +58,6 @@ class Mux extends Base {
 
     /** @type {Data} */
     this.Data = new Data(this);
-
-    this.Webhooks = new Webhooks(this);
   }
 }
 
@@ -67,5 +65,7 @@ class Mux extends Base {
  * @ {JWT}
  */
 Mux.JWT = JWT;
+
+Mux.Webhooks = Webhooks;
 
 module.exports = Mux;

--- a/src/webhooks/resources/verify_header.js
+++ b/src/webhooks/resources/verify_header.js
@@ -1,0 +1,104 @@
+const crypto = require('crypto');
+const DEFAULT_TOLERANCE = 300; // 5 minutes
+const EXPECTED_SCHEME = 'v1';
+
+const Base = require('../../base');
+
+/**
+ * Secure compare, from https://github.com/freewil/scmp
+*/
+function _secureCompare (a, b) {
+  a = Buffer.from(a);
+  b = Buffer.from(b);
+
+  // return early here if buffer lengths are not equal since timingSafeEqual
+  // will throw if buffer lengths are not equal
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  // use crypto.timingSafeEqual if available (since Node.js v6.6.0),
+  // otherwise use our own scmp-internal function.
+  if (crypto.timingSafeEqual) {
+    return crypto.timingSafeEqual(a, b);
+  }
+
+  const len = a.length;
+  let result = 0;
+
+  for (let i = 0; i < len; ++i) {
+    result |= a[i] ^ b[i];
+  }
+  return result === 0;
+}
+
+class VerifyHeader extends Base {
+  parseHeader (header, scheme = EXPECTED_SCHEME) {
+    if (typeof header !== 'string') {
+      return null;
+    }
+
+    return header.split(',').reduce(
+      (accum, item) => {
+        const kv = item.split('=');
+
+        if (kv[0] === 't') {
+          accum.timestamp = kv[1];
+        }
+
+        if (kv[0] === scheme) {
+          accum.signatures.push(kv[1]);
+        }
+
+        return accum;
+      },
+      {
+        timestamp: -1,
+        signatures: [],
+      }
+    );
+  }
+
+  computeSignature (payload, secret) {
+    return crypto
+      .createHmac('sha256', secret)
+      .update(payload, 'utf8')
+      .digest('hex');
+  }
+
+  verify (payload, header, secret, tolerance = DEFAULT_TOLERANCE) {
+    payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
+    header = Buffer.isBuffer(header) ? header.toString('utf8') : header;
+
+    const details = this.parseHeader(header);
+
+    if (!details || details.timestamp === -1) {
+      throw new Error('Unable to extract timestamp and signatures from header');
+    }
+
+    if (!details.signatures.length) {
+      throw new Error('No signatures found with expected scheme');
+    }
+
+    const expectedSignature = this.computeSignature(
+      `${details.timestamp}.${payload}`,
+      secret
+    );
+
+    const signatureFound = !!details.signatures.filter((sig) => _secureCompare(sig, expectedSignature)).length;
+
+    if (!signatureFound) {
+      throw new Error('No signatures found matching the expected signature for payload.')
+    }
+
+    const timestampAge = Math.floor(Date.now() / 1000) - details.timestamp;
+
+    if (tolerance > 0 && timestampAge > tolerance) {
+      throw new Error('Timestamp outside the tolerance zone')
+    }
+
+    return true;
+  }
+}
+
+module.exports = VerifyHeader;

--- a/src/webhooks/resources/verify_header.js
+++ b/src/webhooks/resources/verify_header.js
@@ -2,8 +2,6 @@ const crypto = require('crypto');
 const DEFAULT_TOLERANCE = 300; // 5 minutes
 const EXPECTED_SCHEME = 'v1';
 
-const Base = require('../../base');
-
 /**
  * Secure compare, from https://github.com/freewil/scmp
 */
@@ -32,8 +30,8 @@ function _secureCompare (a, b) {
   return result === 0;
 }
 
-class VerifyHeader extends Base {
-  parseHeader (header, scheme = EXPECTED_SCHEME) {
+class VerifyHeader {
+  static parseHeader (header, scheme = EXPECTED_SCHEME) {
     if (typeof header !== 'string') {
       return null;
     }
@@ -59,14 +57,14 @@ class VerifyHeader extends Base {
     );
   }
 
-  computeSignature (payload, secret) {
+  static computeSignature (payload, secret) {
     return crypto
       .createHmac('sha256', secret)
       .update(payload, 'utf8')
       .digest('hex');
   }
 
-  verify (payload, header, secret, tolerance = DEFAULT_TOLERANCE) {
+  static verify (payload, header, secret, tolerance = DEFAULT_TOLERANCE) {
     payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
     header = Buffer.isBuffer(header) ? header.toString('utf8') : header;
 

--- a/src/webhooks/webhooks.js
+++ b/src/webhooks/webhooks.js
@@ -49,8 +49,7 @@ class Webhooks extends Base {
    * // Verify a webhook signature
    * Webhooks.verifyHeader(body, signature, secret);
    *
-   * // TODO - update "see" link
-   * @see https://docs.mux.com/reference#list-assets
+   * @see https://docs.mux.com/docs/webhook-security
    */
   verifyHeader (...args) {
     return this.VerifyHeader.verify(...args);

--- a/src/webhooks/webhooks.js
+++ b/src/webhooks/webhooks.js
@@ -1,35 +1,18 @@
 /* globals Buffer */
-const Base = require('../base');
 const VerifyHeader = require('./resources/verify_header');
 
 /**
- * Webhooks Class - Provides access to the Mux Webhooks signature verification
- * @extends Base
+ * Webhooks - Provides access to the Mux Webhooks signature verification
  *
  * @example
- * const muxClient = new Mux(accessToken, secret);
- * const { Webhooks } = muxClient;
+ * const Mux = require('mux');
+ * const { Webhooks } = Mux;
  *
  * // Verify a webhook signature
  * Webhooks.verifyHeader(body, signature, secret);
+ *
  */
-class Webhooks extends Base {
-  /**
-   * Webhooks Constructor
-   *
-   * @param {string} accessToken - Mux API Access Token
-   * @param {string} secret - Mux API secret
-   * @constructor
-   */
-  constructor(...params) {
-    super(...params);
-    /**
-      @private
-      @ignore
-    **/
-    this.VerifyHeader = new VerifyHeader(this);
-  }
-
+class Webhooks {
   /**
    * Verify a webhook signature. When enabled, Mux will send webhooks with a signature
    * in the http request header 'Mux-Signature'. You can use that signature to verify
@@ -43,7 +26,8 @@ class Webhooks extends Base {
    * @throws {Error} throw error when a webhook signature verification fails.
    *
    * @example
-   * const { Webhooks } = new Mux(accessToken, secret);
+   * const Mux = require('mux');
+   * const { Webhooks } = Mux;
    *
    *
    * // Verify a webhook signature
@@ -51,8 +35,8 @@ class Webhooks extends Base {
    *
    * @see https://docs.mux.com/docs/webhook-security
    */
-  verifyHeader (...args) {
-    return this.VerifyHeader.verify(...args);
+  static verifyHeader (...args) {
+    return VerifyHeader.verify(...args);
   }
 }
 

--- a/src/webhooks/webhooks.js
+++ b/src/webhooks/webhooks.js
@@ -1,0 +1,60 @@
+/* globals Buffer */
+const Base = require('../base');
+const VerifyHeader = require('./resources/verify_header');
+
+/**
+ * Webhooks Class - Provides access to the Mux Webhooks signature verification
+ * @extends Base
+ *
+ * @example
+ * const muxClient = new Mux(accessToken, secret);
+ * const { Webhooks } = muxClient;
+ *
+ * // Verify a webhook signature
+ * Webhooks.verifyHeader(body, signature, secret);
+ */
+class Webhooks extends Base {
+  /**
+   * Webhooks Constructor
+   *
+   * @param {string} accessToken - Mux API Access Token
+   * @param {string} secret - Mux API secret
+   * @constructor
+   */
+  constructor(...params) {
+    super(...params);
+    /**
+      @private
+      @ignore
+    **/
+    this.VerifyHeader = new VerifyHeader(this);
+  }
+
+  /**
+   * Verify a webhook signature. When enabled, Mux will send webhooks with a signature
+   * in the http request header 'Mux-Signature'. You can use that signature to verify
+   * that the webhook is indeed coming from Mux.
+   *
+   * @param {string} body - The raw request body from Mux. This is stringified JSON.
+   * @param {string} signature - The signature that was in the request header.
+   * @param {string} secret - The webhook signing secret (get this from your dashboard).
+   * @returns {boolean} - Returns true if the signature is verified.
+   *
+   * @throws {Error} throw error when a webhook signature verification fails.
+   *
+   * @example
+   * const { Webhooks } = new Mux(accessToken, secret);
+   *
+   *
+   * // Verify a webhook signature
+   * Webhooks.verifyHeader(body, signature, secret);
+   *
+   * // TODO - update "see" link
+   * @see https://docs.mux.com/reference#list-assets
+   */
+  verifyHeader (...args) {
+    return this.VerifyHeader.verify(...args);
+  }
+}
+
+module.exports = Webhooks;

--- a/test/unit/mux.spec.js
+++ b/test/unit/mux.spec.js
@@ -19,5 +19,11 @@ describe('Unit::Mux', () => {
       expect(Mux.JWT.sign).to.be.a('function');
       expect(Mux.JWT.decode).to.be.a('function');
     });
+
+    it('exposes Webhooks.verifyHeader', () => {
+      const muxClient = new Mux('testKey', 'testSecret');
+      const { Webhooks } = muxClient;
+      expect(Webhooks.verifyHeader).to.be.a('function');
+    });
   });
 });

--- a/test/unit/mux.spec.js
+++ b/test/unit/mux.spec.js
@@ -15,15 +15,15 @@ describe('Unit::Mux', () => {
       expect(Data).to.to.be.an.instanceof(MuxData);
     });
 
+    /** @test {Mux.JTW} */
     it('exposes JWT Helper utilities as static methods', () => {
       expect(Mux.JWT.sign).to.be.a('function');
       expect(Mux.JWT.decode).to.be.a('function');
     });
 
+    /** @test {Mux.Webhooks} */
     it('exposes Webhooks.verifyHeader', () => {
-      const muxClient = new Mux('testKey', 'testSecret');
-      const { Webhooks } = muxClient;
-      expect(Webhooks.verifyHeader).to.be.a('function');
+      expect(Mux.Webhooks.verifyHeader).to.be.a('function');
     });
   });
 });

--- a/test/unit/webhooks/resources/verify_header.spec.js
+++ b/test/unit/webhooks/resources/verify_header.spec.js
@@ -1,0 +1,113 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const VerifyHeader = require('../../../../src/webhooks/resources/verify_header');
+
+/** @test {VerifyHeader} */
+describe('Unit::VerifyHeader', () => {
+  const testApiKey = 'testApiKey';
+  const testSecret = 'testSecret';
+  const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+
+  /** @test {VerifyHeader} */
+  describe('VerifyHeader', () => {
+    /** @test {VerifyHeader} */
+    it('throws an error if an api key is not given', () => {
+      expect(() => new VerifyHeader()).to.throw('API Access Token must be provided.');
+    });
+
+    /** @test {VerifyHeader} */
+    it('throws an error if a secret key is not given', () => {
+      expect(() => new VerifyHeader('testKey')).to.throw(
+        'API secret key must be provided'
+      );
+    });
+
+    /** @test {VerifyHeader} */
+    it('creates a new VerifyHeader instance', () => {
+      const TestVerifyHeader = new VerifyHeader(testApiKey, testSecret);
+      expect(() => new VerifyHeader(testApiKey, testSecret)).to.not.throw();
+      expect(TestVerifyHeader.tokenId).to.equal(testApiKey);
+      expect(TestVerifyHeader.tokenSecret).to.equal(testSecret);
+    });
+
+    /** @test {VerifyHeader.parseHeader} */
+    describe('parseHeader with a known-hard coded header value', () => {
+      it('will correctly parse the header value to the known timestamp and signature', () => {
+        /*
+          This header value was generated from Mux's backend code with the following values:
+            * secret: 'SuperSecret123'
+            * body: "{\"test\":\"body\"}"
+            * time: 1565125718 (08/06/2019 @ 9:08pm UTC)
+        */
+        const header = "t=1565125718,v1=854ece4c22acef7c66b57d4e504153bc512595e8e9c772ece2a68150548c19a7";
+        const expectedSignature = "854ece4c22acef7c66b57d4e504153bc512595e8e9c772ece2a68150548c19a7";
+        const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+        const parsed = verifyHeader.parseHeader(header);
+        expect(parsed.timestamp).to.equal('1565125718');
+        expect(parsed.signatures.length).to.equal(1);
+        expect(parsed.signatures[0]).to.equal(expectedSignature);
+      });
+    });
+
+    /** @test {VerifyHeader.verify} */
+    describe('verify', () => {
+      const payload = "{\"test\":\"body\"}";
+      const secret = "SuperSecret123";
+      const validTimeSec = 1565125718;
+      const validHeaderAtTheTime = "t=1565125718,v1=854ece4c22acef7c66b57d4e504153bc512595e8e9c772ece2a68150548c19a7";
+
+      /** @test {VerifyHeader.verify} */
+      describe('with a malformatted header value', () => {
+        /** @test {VerifyHeader.verify} */
+        it('will throw an unable to extract timestamp and signatures error', () => {
+          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+          expect(() => {
+            verifyHeader.verify(payload, 'somebadheadervalue', secret);
+          }).to.throw('Unable to extract timestamp and signatures from header')
+        });
+      });
+
+      /** @test {VerifyHeader.verify} */
+      describe('with a header value that has the wrong scheme', () => {
+        /** @test {VerifyHeader.verify} */
+        it('will throw a no signatures found with expected scheme error', () => {
+          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+          expect(() => {
+            const header = "t=1565125718,v2=weiorwer";
+            verifyHeader.verify(payload, header, secret);
+          }).to.throw('No signatures found with expected scheme')
+        });
+      });
+
+      /** @test {VerifyHeader.verify} */
+      describe('with a header value that is valid expect that it is outside the tolerated time range', () => {
+        /** @test {VerifyHeader.verify} */
+        it('will throw a timestamp outside the tolerance zone error', () => {
+          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+          expect(() => {
+            verifyHeader.verify(payload, validHeaderAtTheTime, secret);
+          }).to.throw('Timestamp outside the tolerance zone');
+        });
+      });
+
+      /** @test {VerifyHeader.verify} */
+      describe('with a header value that is actually valid', () => {
+        let clock;
+
+        beforeEach(() => {
+          clock = sinon.useFakeTimers(new Date(validTimeSec * 1000))
+        })
+
+        afterEach(() => clock.restore())
+
+        /** @test {VerifyHeader.verify} */
+        it('will return true', () => {
+          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+          const isVerified = verifyHeader.verify(payload, validHeaderAtTheTime, secret);
+          expect(isVerified).to.be.true;
+        });
+      });
+    });
+  });
+});
+

--- a/test/unit/webhooks/resources/verify_header.spec.js
+++ b/test/unit/webhooks/resources/verify_header.spec.js
@@ -51,7 +51,7 @@ describe('Unit::VerifyHeader', () => {
 
     /** @test {VerifyHeader.verify} */
     describe('verify', () => {
-      const payload = "{\"test\":\"body\"}";
+      let payload = "{\"test\":\"body\"}";
       const secret = "SuperSecret123";
       const validTimeSec = 1565125718;
       const validHeaderAtTheTime = "t=1565125718,v1=854ece4c22acef7c66b57d4e504153bc512595e8e9c772ece2a68150548c19a7";
@@ -101,8 +101,16 @@ describe('Unit::VerifyHeader', () => {
         afterEach(() => clock.restore())
 
         /** @test {VerifyHeader.verify} */
-        it('will return true', () => {
+        it('will return true when the payload is a string', () => {
           const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+          const isVerified = verifyHeader.verify(payload, validHeaderAtTheTime, secret);
+          expect(isVerified).to.be.true;
+        });
+
+        /** @test {VerifyHeader.verify} */
+        it('will return true when the payload is a buffer', () => {
+          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
+          payload = Buffer.from(payload)
           const isVerified = verifyHeader.verify(payload, validHeaderAtTheTime, secret);
           expect(isVerified).to.be.true;
         });

--- a/test/unit/webhooks/resources/verify_header.spec.js
+++ b/test/unit/webhooks/resources/verify_header.spec.js
@@ -6,30 +6,9 @@ const VerifyHeader = require('../../../../src/webhooks/resources/verify_header')
 describe('Unit::VerifyHeader', () => {
   const testApiKey = 'testApiKey';
   const testSecret = 'testSecret';
-  const verifyHeader = new VerifyHeader(testApiKey, testSecret);
 
   /** @test {VerifyHeader} */
   describe('VerifyHeader', () => {
-    /** @test {VerifyHeader} */
-    it('throws an error if an api key is not given', () => {
-      expect(() => new VerifyHeader()).to.throw('API Access Token must be provided.');
-    });
-
-    /** @test {VerifyHeader} */
-    it('throws an error if a secret key is not given', () => {
-      expect(() => new VerifyHeader('testKey')).to.throw(
-        'API secret key must be provided'
-      );
-    });
-
-    /** @test {VerifyHeader} */
-    it('creates a new VerifyHeader instance', () => {
-      const TestVerifyHeader = new VerifyHeader(testApiKey, testSecret);
-      expect(() => new VerifyHeader(testApiKey, testSecret)).to.not.throw();
-      expect(TestVerifyHeader.tokenId).to.equal(testApiKey);
-      expect(TestVerifyHeader.tokenSecret).to.equal(testSecret);
-    });
-
     /** @test {VerifyHeader.parseHeader} */
     describe('parseHeader with a known-hard coded header value', () => {
       it('will correctly parse the header value to the known timestamp and signature', () => {
@@ -41,8 +20,7 @@ describe('Unit::VerifyHeader', () => {
         */
         const header = "t=1565125718,v1=854ece4c22acef7c66b57d4e504153bc512595e8e9c772ece2a68150548c19a7";
         const expectedSignature = "854ece4c22acef7c66b57d4e504153bc512595e8e9c772ece2a68150548c19a7";
-        const verifyHeader = new VerifyHeader(testApiKey, testSecret);
-        const parsed = verifyHeader.parseHeader(header);
+        const parsed = VerifyHeader.parseHeader(header);
         expect(parsed.timestamp).to.equal('1565125718');
         expect(parsed.signatures.length).to.equal(1);
         expect(parsed.signatures[0]).to.equal(expectedSignature);
@@ -60,9 +38,8 @@ describe('Unit::VerifyHeader', () => {
       describe('with a malformatted header value', () => {
         /** @test {VerifyHeader.verify} */
         it('will throw an unable to extract timestamp and signatures error', () => {
-          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
           expect(() => {
-            verifyHeader.verify(payload, 'somebadheadervalue', secret);
+            VerifyHeader.verify(payload, 'somebadheadervalue', secret);
           }).to.throw('Unable to extract timestamp and signatures from header')
         });
       });
@@ -71,10 +48,9 @@ describe('Unit::VerifyHeader', () => {
       describe('with a header value that has the wrong scheme', () => {
         /** @test {VerifyHeader.verify} */
         it('will throw a no signatures found with expected scheme error', () => {
-          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
           expect(() => {
             const header = "t=1565125718,v2=weiorwer";
-            verifyHeader.verify(payload, header, secret);
+            VerifyHeader.verify(payload, header, secret);
           }).to.throw('No signatures found with expected scheme')
         });
       });
@@ -83,9 +59,8 @@ describe('Unit::VerifyHeader', () => {
       describe('with a header value that is valid expect that it is outside the tolerated time range', () => {
         /** @test {VerifyHeader.verify} */
         it('will throw a timestamp outside the tolerance zone error', () => {
-          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
           expect(() => {
-            verifyHeader.verify(payload, validHeaderAtTheTime, secret);
+            VerifyHeader.verify(payload, validHeaderAtTheTime, secret);
           }).to.throw('Timestamp outside the tolerance zone');
         });
       });
@@ -102,16 +77,14 @@ describe('Unit::VerifyHeader', () => {
 
         /** @test {VerifyHeader.verify} */
         it('will return true when the payload is a string', () => {
-          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
-          const isVerified = verifyHeader.verify(payload, validHeaderAtTheTime, secret);
+          const isVerified = VerifyHeader.verify(payload, validHeaderAtTheTime, secret);
           expect(isVerified).to.be.true;
         });
 
         /** @test {VerifyHeader.verify} */
         it('will return true when the payload is a buffer', () => {
-          const verifyHeader = new VerifyHeader(testApiKey, testSecret);
           payload = Buffer.from(payload)
-          const isVerified = verifyHeader.verify(payload, validHeaderAtTheTime, secret);
+          const isVerified = VerifyHeader.verify(payload, validHeaderAtTheTime, secret);
           expect(isVerified).to.be.true;
         });
       });

--- a/test/unit/webhooks/webhooks.spec.js
+++ b/test/unit/webhooks/webhooks.spec.js
@@ -4,31 +4,6 @@ const Webhooks = require('../../../src/webhooks/webhooks');
 
 /** @test {Webhooks} */
 describe('Unit::Webhooks', () => {
-  const testApiKey = 'testApiKey';
-  const testSecret = 'testSecret';
-
-  /** @test {Webhooks} */
-  describe('Webhooks', () => {
-    /** @test {Webhooks} */
-    it('throws an error if an api key is not given', () => {
-      expect(() => new Webhooks()).to.throw('API Access Token must be provided.');
-    });
-
-    /** @test {Webhooks} */
-    it('throws an error if a secret key is not given', () => {
-      expect(() => new Webhooks('testKey')).to.throw(
-        'API secret key must be provided'
-      );
-    });
-
-    /** @test {Webhooks} */
-    it('creates a new Webhooks instance', () => {
-      const TestWebhooks = new Webhooks(testApiKey, testSecret);
-      expect(() => new Webhooks(testApiKey, testSecret)).to.not.throw();
-      expect(TestWebhooks.verifyHeader).to.be.a('function');
-    });
-  });
-
   /** @test {Webhooks.verifyHeader} */
   describe('verifyHeader', () => {
     const payload = "{\"test\":\"body\"}";
@@ -45,8 +20,7 @@ describe('Unit::Webhooks', () => {
 
     /** @test {Webhooks.verifyHeader} */
     it('returns true for a valid header', () => {
-      const webhooks = new Webhooks(testApiKey, testSecret);
-      expect(webhooks.verifyHeader(payload, validHeaderAtTheTime, secret)).to.be.true;
+      expect(Webhooks.verifyHeader(payload, validHeaderAtTheTime, secret)).to.be.true;
     });
   });
 });

--- a/test/unit/webhooks/webhooks.spec.js
+++ b/test/unit/webhooks/webhooks.spec.js
@@ -1,0 +1,52 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const Webhooks = require('../../../src/webhooks/webhooks');
+
+/** @test {Webhooks} */
+describe('Unit::Webhooks', () => {
+  const testApiKey = 'testApiKey';
+  const testSecret = 'testSecret';
+
+  /** @test {Webhooks} */
+  describe('Webhooks', () => {
+    /** @test {Webhooks} */
+    it('throws an error if an api key is not given', () => {
+      expect(() => new Webhooks()).to.throw('API Access Token must be provided.');
+    });
+
+    /** @test {Webhooks} */
+    it('throws an error if a secret key is not given', () => {
+      expect(() => new Webhooks('testKey')).to.throw(
+        'API secret key must be provided'
+      );
+    });
+
+    /** @test {Webhooks} */
+    it('creates a new Webhooks instance', () => {
+      const TestWebhooks = new Webhooks(testApiKey, testSecret);
+      expect(() => new Webhooks(testApiKey, testSecret)).to.not.throw();
+      expect(TestWebhooks.verifyHeader).to.be.a('function');
+    });
+  });
+
+  /** @test {Webhooks.verifyHeader} */
+  describe('verifyHeader', () => {
+    const payload = "{\"test\":\"body\"}";
+    const secret = "SuperSecret123";
+    const validTimeSec = 1565125718;
+    const validHeaderAtTheTime = "t=1565125718,v1=854ece4c22acef7c66b57d4e504153bc512595e8e9c772ece2a68150548c19a7";
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(new Date(validTimeSec * 1000))
+    })
+
+    afterEach(() => clock.restore())
+
+    /** @test {Webhooks.verifyHeader} */
+    it('returns true for a valid header', () => {
+      const webhooks = new Webhooks(testApiKey, testSecret);
+      expect(webhooks.verifyHeader(payload, validHeaderAtTheTime, secret)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
This is a first rough stab at this. So, feedback please <3.

I based this implementation entirely on the stripe sdk [source](https://github.com/stripe/stripe-node/blob/68da1c786405bee1f1bbe0bebba2ec6de0c34386/lib/Webhooks.js#L70)

Public API:

```javascript
const Mux = require('@mux/mux-node');
const { Webhooks } = Mux;
// returns `true` if verified otherwise throws one of four errors
Webhooks.verifyHeader(body, signature, secret);
```

~One note about this Public API implementation:~

* ~Technically for `Webhooks.verifyHeader` we don't need the `accessToken` and `secret`, so if we want, `Webhooks` could be static on the `Mux` variable, similar to how the JWT helper works. Because of #12 I thought in the future we would expose other functionality on `Webhooks` (for example `Webhooks.create` or `Webhooks.get`) so I did my best to implement it in a similar way to `{ Video}` and `{ Data}`.~

---

TODO:

- [ ] agree on the public API
- [x] Documentation - all the code in `src/` is very nicely documented with comments. I think I am supposed to do that same with all of my new code and then run `yarn esdoc` and commit the doc changes. That all ends up living here, right? https://muxinc.github.io/mux-node-sdk/. Please confirm what I have to do to keep this all up to date.
- [x] Full end-to-end QA
- [x] Update README and generated code with links to https://docs.mux.com/docs/webhooks-security