### PR TITLE
Use hard-coded fake crendentials when running test:int

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs": "esdoc",
     "test": "yarn mocha --recursive ./test",
     "test:unit": "mocha --recursive ./test/unit",
-    "test:int": "NOCK_BACK_MODE=record mocha --recursive ./test/integration --timeout 10000",
+    "test:int": "MUX_TOKEN_ID=fake-token-id MUX_TOKEN_SECRET=fake-token-secret NOCK_BACK_MODE=record mocha --recursive ./test/integration --timeout 10000",
     "test:int:wild": "NOCK_BACK_MODE=wild mocha --recursive ./test/integration --timeout 10000",
     "format": "eslint src/** test/** types/** --no-error-on-unmatched-pattern",
     "lint": "yarn format"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs": "esdoc",
     "test": "yarn mocha --recursive ./test",
     "test:unit": "mocha --recursive ./test/unit",
-    "test:int": "MUX_TOKEN_ID=fake-token-id MUX_TOKEN_SECRET=fake-token-secret NOCK_BACK_MODE=record mocha --recursive ./test/integration --timeout 10000",
+    "test:int": "NOCK_BACK_MODE=record mocha --recursive ./test/integration --timeout 10000",
     "test:int:wild": "NOCK_BACK_MODE=wild mocha --recursive ./test/integration --timeout 10000",
     "format": "eslint src/** test/** types/** --no-error-on-unmatched-pattern",
     "lint": "yarn format"

--- a/test/integration/_helper.js
+++ b/test/integration/_helper.js
@@ -1,6 +1,10 @@
 const path = require('path');
 const nockBack = require('nock').back;
 
+process.env.MUX_TOKEN_ID = process.env.MUX_TOKEN_ID || 'fake-token-id';
+process.env.MUX_TOKEN_SECRET =
+  process.env.MUX_TOKEN_SECRET || 'fake-token-secret';
+
 before(() => {
   // If we decide to use nock with other modules we should move this to a test helper
   nockBack.fixtures = path.join(__dirname, '/nockFixtures');


### PR DESCRIPTION
These env vars are requiring for running these integration tests. No real API requests are made, they are run against recorded requests.

Since these tests also get run in forks of this repo, we don't have access to any ENV vars that are set in TravisCI, so let's hard-code them here.