### PR TITLE
Mark asset.master as optional

### DIFF
--- a/types/interfaces/Asset.ts
+++ b/types/interfaces/Asset.ts
@@ -21,7 +21,7 @@ export declare interface Asset {
   mp4_support: AssetMp4Support;
   static_renditions: StaticRenditions;
   master_access: AssetMasterAccess;
-  master: AssetMaster;
+  master?: AssetMaster;
   passthrough: string;
   errors: AssetError;
 }


### PR DESCRIPTION
The API doesn't always return a `master` property, so the Asset interface should mark the property as optional to ensure that consumers of the library appropriately handle the case where the `master` property is not present.