### PR TITLE
Documentation fix - Mux Signature with wrong casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Verifying Webhook Signatures is *optional*. Learn more in our [Webhook Security 
 
 /*
   `payload` is the raw request body. It should be a string representation of a JSON object.
-  `header` is the value in request.headers['Mux-Signature']
+  `header` is the value in request.headers['mux-signature']
   `secret` is the signing secret for this configured webhook. You can find that in your webhooks dashboard
            (note that this secret is different than your API Secret Key)
 */


### PR DESCRIPTION
Not sure if it was intentionally kept so in the documentation, feel free to reject if so. The example below was correct, but the explanation used capital casing which won't be a valid header Node/Express