### PR TITLE
prep 3.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.3
+
+- Typescript bugfix: Change JWTOptions type declaration to correctly mark some fields as optional
+
 ## 3.0.2
 
 - Typescript bugfix: Change types/interfaces/Asset.ts to correctly mark some fields as optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mux/mux-node",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Mux API wrapper",
   "keywords": [
     "mux",


### PR DESCRIPTION
Changes between this branch and v3.0.2 tag can be seen here:

https://github.com/muxinc/mux-node-sdk/compare/v3.0.2...dj/release-3-0-3

#69 is the only code change, all other changes were for documentation