### PR TITLE
Provide a default export

### DIFF
--- a/src/mux.js
+++ b/src/mux.js
@@ -69,4 +69,6 @@ Mux.JWT = JWT;
 
 Mux.Webhooks = Webhooks;
 
+Mux.default = Mux;
+
 module.exports = Mux;


### PR DESCRIPTION
This is necessary for proper ES6-style importing. See: https://stackoverflow.com/questions/40294870/module-exports-vs-export-default-in-node-js-and-es6

I think this is the cause of #61.