### PR TITLE
Further improve typescript typings for 'Mux.JWT.sign()'

### DIFF
--- a/types/mux.d.ts
+++ b/types/mux.d.ts
@@ -143,7 +143,7 @@ export declare class Uploads extends Base {
 }
 
 export declare interface JWTOptions {
-  type: string;
+  type?: 'video' | 'thumbnail' | 'gif';
   keyId?: string;
   keySecret?: string;
   expiration?: string;


### PR DESCRIPTION
• mark 'type' as optional
• stronger type for 'type'