### PR TITLE
Allow storyboard signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ Video.Assets.create({
 
 ## Verifying Webhook Signatures
 
-Verifying Webhook Signatures is *optional*. Learn more in our [Webhook Security Guide](https://docs.mux.com/docs/webhook-security)
-
+Verifying Webhook Signatures is _optional_. Learn more in our [Webhook Security Guide](https://docs.mux.com/docs/webhook-security)
 
 ```javascript
 /*
@@ -149,22 +148,26 @@ const app = express();
 
 app.post(
   '/webhooks',
-  bodyParser.raw({type: 'application/json'}),
+  bodyParser.raw({ type: 'application/json' }),
   async (req, res) => {
     try {
       const sig = req.headers['mux-signature'];
       // returns a `boolean` with value `true` if the signature is valid
-      const isValidSignature = Webhooks.verifyHeader(req.body, sig, webhookSecret);
+      const isValidSignature = Webhooks.verifyHeader(
+        req.body,
+        sig,
+        webhookSecret
+      );
       console.log('Success:', isValidSignature);
       // convert the raw req.body to JSON, which is originally Buffer (raw)
       const jsonFormattedBody = JSON.parse(req.body);
       // await doSomething();
-      res.json({received: true});
+      res.json({ received: true });
     } catch (err) {
       // On error, return the error message
       return res.status(400).send(`Webhook Error: ${err.message}`);
     }
-   }
+  }
 );
 
 app.listen(3000, () => {
@@ -186,13 +189,22 @@ const token = Mux.JWT.sign('some-playback-id');
 // https://stream.mux.com/some-playback-id.m3u8?token=${token}
 
 // If you wanted to sign a thumbnail
-const thumbParams = { time: 14, width: 100 }
-const thumbToken = Mux.JWT.sign('some-playback-id', { type: 'thumbnail', params: thumbParams });
+const thumbParams = { time: 14, width: 100 };
+const thumbToken = Mux.JWT.sign('some-playback-id', {
+  type: 'thumbnail',
+  params: thumbParams,
+});
 // https://image.mux.com/some-playback-id/thumbnail.jpg?token=${token}
 
 // If you wanted to sign a gif
 const gifToken = Mux.JWT.sign('some-playback-id', { type: 'gif' });
 // https://image.mux.com/some-playback-id/animated.gif?token=${token}
+
+// And, an example for a storyboard
+const storyboardToken = Mux.JWT.sign('some-playback-id', {
+  type: 'storyboard',
+});
+// https://image.mux.com/some-playback-id/storyboard.jpg?token=${token}
 ```
 
 ## `request` and `response` events
@@ -239,4 +251,3 @@ Find a bug or want to add a useful feature? That'd be amazing! If you'd like to 
 5. Open the pull request! :tada:
 
 Running integration tests will require a Mux account with valid seed data for `/video` and `/data` endpoints. If you are contributing and you don't have this, please add unit test coverage and someone from the Mux will help get integration tests added if necessary.
-

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -69,7 +69,7 @@ class JWT {
    * @param {Object} options - Configuration options to use when creating the token
    * @param {string} [options.keyId] - The signing key ID to use. If not specified, process.env.MUX_SIGNING_KEY is attempted
    * @param {string} [options.keySecret] - The signing key secret. If not specified, process.env.MUX_PRIVATE_KEY is used.
-   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, or `storyboard
+   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, or `storyboard`
    * @param {string} [options.expiration=7d] - Length of time for the token to be valid.
    * @param {Object} [options.params] - Any additional query params you'd use with a public url. For example, with a thumbnail this would be values such as `time`.
    * @returns {string} - Returns a token to be used with a signed URL.

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -11,6 +11,7 @@ const typeToClaim = type => {
     video: 'v',
     thumbnail: 't',
     gif: 'g',
+    storyboard: 's',
   };
 
   return typeMap[type];
@@ -68,7 +69,7 @@ class JWT {
    * @param {Object} options - Configuration options to use when creating the token
    * @param {string} [options.keyId] - The signing key ID to use. If not specified, process.env.MUX_SIGNING_KEY is attempted
    * @param {string} [options.keySecret] - The signing key secret. If not specified, process.env.MUX_PRIVATE_KEY is used.
-   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, or `gif`
+   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, or `storyboard
    * @param {string} [options.expiration=7d] - Length of time for the token to be valid.
    * @param {Object} [options.params] - Any additional query params you'd use with a public url. For example, with a thumbnail this would be values such as `time`.
    * @returns {string} - Returns a token to be used with a signed URL.

--- a/test/unit/utils/jwt.spec.js
+++ b/test/unit/utils/jwt.spec.js
@@ -60,6 +60,18 @@ describe('Utils::JWT', () => {
       expect(decoded.aud).to.eq('g');
     });
 
+    it('maps type storyboard to s', () => {
+      const options = {
+        keyId: TEST_ID,
+        keySecret: TEST_SECRET,
+        type: 'storyboard',
+      };
+      const token = JWT.sign('some-playback-id', options);
+      expect(token).to.be.a('string');
+      const decoded = JWT.decode(token);
+      expect(decoded.aud).to.eq('s');
+    });
+
     it('takes a file path for a secret', () => {
       const options = {
         keyId: TEST_ID,

--- a/types/mux.d.ts
+++ b/types/mux.d.ts
@@ -143,7 +143,7 @@ export declare class Uploads extends Base {
 }
 
 export declare interface JWTOptions {
-  type?: 'video' | 'thumbnail' | 'gif';
+  type?: 'video' | 'thumbnail' | 'gif' | 'storyboard';
   keyId?: string;
   keySecret?: string;
   expiration?: string;


### PR DESCRIPTION
Adheres to the docs as described in guide located at https://docs.mux.com/docs/storyboard-guide#are-signed-urls-supported.

Looks like prettier made a few add'l changes, let me know if this needs reformatted