### PR TITLE
Bump axios version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "yarn format"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "esdoc-ecmascript-proposal-plugin": "^1.0.0",
     "jsonwebtoken": "^8.4.0"
   },


### PR DESCRIPTION
I'm getting a dependabot alert for axios but this repo's version pin prevents it from being updated. Does a newer version work?

The relevant CVE: https://github.com/advisories/GHSA-4w2v-q235-vp99