### PR TITLE
Fix wrong parameter ins Assets.deletePlaybackId type

### DIFF
--- a/types/mux.d.ts
+++ b/types/mux.d.ts
@@ -118,7 +118,7 @@ export declare class Assets extends Base {
     assetId: string,
     params: CreatePlaybackIdParams
   ): Promise<PlaybackId>;
-  deletePlaybackId(liveStreamId: string, playbackId: string): Promise<any>;
+  deletePlaybackId(assetId: string, playbackId: string): Promise<any>;
   deleteTrack(assetId: string): Promise<any>;
   updateMp4Support(
     assetId: string,


### PR DESCRIPTION
Based on https://github.com/muxinc/mux-node-sdk/blob/master/src/video/resources/assets.js the parameter liveStreamId is incorrect on the deletePlaybackId function. 