### PR TITLE
bump axios dep to ^0.21.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mux/mux-node",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Mux API wrapper",
   "keywords": [
     "mux",


### PR DESCRIPTION
closes #134 and #130 

This is due to a regression in axios `0.21.2` where our response interceptor was not getting run (https://github.com/axios/axios/pull/4013)

diff: https://github.com/muxinc/mux-node-sdk/compare/v3.3.0...v3.3.1