### PR TITLE
[Enhancement] Update outdated direct uploads examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ const playbackId = await Video.Assets.createPlaybackId(asset.id, {
 
 Or, if you don't have the files online already, you can ingest one via the direct uploads API.
 
+Note: Since 2019, request has gone into maintenance mode. We must use an alternate request library such as `node-fetch`.
+
+`node-fetch` supports both CommonJS (`require` syntax) and ESM (`import` syntax). [With v3, you must use ESM. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
+
 ```javascript
 const fs = require('fs')
 const fetch = require('node-fetch');

--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ const playbackId = await Video.Assets.createPlaybackId(asset.id, {
 
 Or, if you don't have the files online already, you can ingest one via the direct uploads API.
 
-Note: Since 2019, request has gone into maintenance mode. We must use an alternate request library such as `node-fetch`.
+Note: Since 2019, request has gone into maintenance mode. 
+We must use an alternate request library such as `node-fetch`.
 
-`node-fetch` supports both CommonJS (`require` syntax) and ESM (`import` syntax). [With v3, you must use ESM. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
+`node-fetch` supports both CommonJS (`require` syntax) and ESM (`import` syntax). 
+[With v3, you must use ESM. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
 
 ```javascript
 const fs = require('fs')

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Then in your file:
 import fetch from 'node-fetch';
 ```
 
-Back to using the direct uploads API if you don't files online already:
+Back to using the direct uploads API if you don't have files online already:
 
 ```javascript
 const fs = require('fs')

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ that will allow you to access the Mux Data and Video APIs.
 
 ```javascript
 const Mux = require('@mux/mux-node');
+
+// make it possible to read credentials from .env files
+const dotenv = require('dotenv');
+dotenv.config();
+
 const { Video, Data } = new Mux(accessToken, secret);
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,31 @@ import fetch from 'node-fetch';
 
 Back to using the direct uploads API if you don't have files online already:
 
+**With CommonJS**
+
 ```javascript
 const fs = require('fs')
 const fetch = require('node-fetch');
+let upload = await Video.Uploads.create({
+  new_asset_settings: { playback_policy: 'public' },
+});
+
+// The URL you get back from the upload API is resumable, and the file can be uploaded using a `PUT` request (or a series of them).
+const readStream = await fs.createReadStream('/path/to/your/file');
+await fetch(upload.url, { method: 'PUT', body: readStream });
+
+// The upload may not be updated immediately, but shortly after the upload is finished you'll get a `video.asset.created` event and the upload will now have a status of `asset_created` and a new `asset_id` key.
+let updatedUpload = await Video.Uploads.get(upload.id);
+
+// Or you could decide to go get additional information about that new asset you created.
+let asset = await Video.Assets.get(updatedUpload['asset_id']);
+```
+
+**With ES6**
+
+```javascript
+import fs from'fs';
+import fetch from'node-fetch';
 let upload = await Video.Uploads.create({
   new_asset_settings: { playback_policy: 'public' },
 });

--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ const playbackId = await Video.Assets.createPlaybackId(asset.id, {
 Or, if you don't have the files online already, you can ingest one via the direct uploads API.
 
 Note: Since 2019, request has gone into maintenance mode. 
+
 We must use an alternate request library such as `node-fetch`.
 
 `node-fetch` supports both CommonJS (`require` syntax) and ESM (`import` syntax). 
+
 [With v3, you must use ESM. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -73,13 +73,39 @@ const playbackId = await Video.Assets.createPlaybackId(asset.id, {
 
 Or, if you don't have the files online already, you can ingest one via the direct uploads API.
 
-Note: Since 2019, request has gone into maintenance mode. 
+However, before that, a word of warning on using request libraries.
+
+### Request Library Usage in Node
+
+Since 2019, `request` has gone into maintenance mode. 
 
 We must use an alternate request library such as `node-fetch`.
 
 `node-fetch` supports both CommonJS (`require` syntax) and ESM (`import` syntax). 
 
-[With v3, you must use ESM. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
+[With v3, you must use ESM only. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
+
+**With CommonJS**
+Install version 2 of `node-fetch`
+```
+npm install node-fetch@2
+```
+Then in your file:
+```javascript
+const fetch = require('node-fetch');
+```
+
+**With ES6**
+```
+npm install node-fetch
+```
+
+Then in your file:
+```javascript
+import fetch from 'node-fetch';
+```
+
+Back to using the direct uploads API if you don't files online already:
 
 ```javascript
 const fs = require('fs')

--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ const playbackId = await Video.Assets.createPlaybackId(asset.id, {
 Or, if you don't have the files online already, you can ingest one via the direct uploads API.
 
 ```javascript
-const request = require('request');
+const fs = require('fs')
+const fetch = require('node-fetch');
 let upload = await Video.Uploads.create({
   new_asset_settings: { playback_policy: 'public' },
 });
 
 // The URL you get back from the upload API is resumable, and the file can be uploaded using a `PUT` request (or a series of them).
-await fs.createReadStream('/path/to/your/file').pipe(request.put(upload.url));
+const readStream = await fs.createReadStream('/path/to/your/file');
+await fetch(upload.url, { method: 'PUT', body: readStream });
 
 // The upload may not be updated immediately, but shortly after the upload is finished you'll get a `video.asset.created` event and the upload will now have a status of `asset_created` and a new `asset_id` key.
 let updatedUpload = await Video.Uploads.get(upload.id);

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ dotenv.config();
 const { Video, Data } = new Mux(accessToken, secret);
 ```
 
+If you're using ESM, you can create a Mux instance like this instead:
+```javascript
+import Mux from '@mux/mux-node';
+
+// make it possible to read credentials from .env files
+import dotenv from 'dotenv';
+dotenv.config();
+
+const { Video, Data } = new Mux(accessToken, secret);
+```
+
 If a token ID and secret aren't included as parameters, the SDK will attempt to use the `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` environment variables.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -90,11 +90,7 @@ However, before that, a word of warning on using request libraries.
 
 Since 2019, `request` has gone into maintenance mode. 
 
-We must use an alternate request library such as `node-fetch`.
-
-`node-fetch` supports both CommonJS (`require` syntax) and ESM (`import` syntax). 
-
-[With v3, you must use ESM only. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
+We must use an alternate request library such as `node-fetch` [here](https://github.com/node-fetch/node-fetch/).
 
 **With CommonJS**
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ We must use an alternate request library such as `node-fetch`.
 [With v3, you must use ESM only. For CommonJS, use v2.](https://github.com/node-fetch/node-fetch#commonjs)
 
 **With CommonJS**
+
 Install version 2 of `node-fetch`
 ```
 npm install node-fetch@2

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ let asset = await Video.Assets.get(updatedUpload['asset_id']);
 **With ES6**
 
 ```javascript
-import fs from'fs';
-import fetch from'node-fetch';
+import fs from 'fs';
+import fetch from 'node-fetch';
 let upload = await Video.Uploads.create({
   new_asset_settings: { playback_policy: 'public' },
 });


### PR DESCRIPTION
## Description
There's a lot of friction when consumers try to follow the current README 👀 

Updated README to address the following points of friction 🚨 

## Friction Notes
Going through the README with fresh eyes, there were three main points of friction:

1. Support reading from `.env` files but this can be remedied with the `dotenv` package.
2. `request` library [hasn't really been maintained since 2019](https://nodesource.com/blog/express-going-into-maintenance-mode). Replaced with `node-fetch`. [Docs can be found here](https://github.com/node-fetch/node-fetch). A gotcha about `node-fetch` is v3 is an ESM-only module (using `import` instead of `require`). If users cannot or do not want to support ESM and would prefer to use `CommonJS` (using `require`), they must use v2. **TL;DR:** Both are possible.
3. Streams. Because we change the request library we're using, there are two places consumers may encounter friction due to unfamiliarity: **a)** `node-fetch` and PUT requests and **b)** streams with `node-fetch` v2 or v3. 

My full and personal friction log in Notion can be found [here](https://leaf-production-962.notion.site/I-want-to-create-a-direct-upload-with-the-Mux-Node-SDK-d423d8d0e787452f96cdcc2111ee6438).

## How was this tested?

Confirmed it works in my own repo and implementation of it.

https://user-images.githubusercontent.com/22087604/156077164-22ad4559-aec7-4c69-8cb7-def96b41c279.mp4
