### PR TITLE
[Enhancement] Update docs to reduce ingest friction

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,9 @@ As an example, you can create a Mux asset and playback ID by using the below fun
 // Create an asset
 const asset = await Video.Assets.create({
   input: 'https://storage.googleapis.com/muxdemofiles/mux-video-intro.mp4',
-});
-```
-
-```javascript
-// ...then later, a playback ID for that asset
-const playbackId = await Video.Assets.createPlaybackId(asset.id, {
-  policy: 'public',
+  "playback_policy": [
+    "public" // makes playback ID available on the asset
+  ],
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ that will allow you to access the Mux Data and Video APIs.
 
 ```javascript
 const Mux = require('@mux/mux-node');
+
+// make it possible to read credentials from .env files
+const dotenv = require('dotenv');
+dotenv.config();
+
 const { Video, Data } = new Mux(accessToken, secret);
 ```
 
@@ -69,13 +74,15 @@ const playbackId = await Video.Assets.createPlaybackId(asset.id, {
 Or, if you don't have the files online already, you can ingest one via the direct uploads API.
 
 ```javascript
-const request = require('request');
+const fs = require('fs')
+const fetch = require('node-fetch');
 let upload = await Video.Uploads.create({
   new_asset_settings: { playback_policy: 'public' },
 });
 
 // The URL you get back from the upload API is resumable, and the file can be uploaded using a `PUT` request (or a series of them).
-await fs.createReadStream('/path/to/your/file').pipe(request.put(upload.url));
+const readStream = await fs.createReadStream('/path/to/your/file');
+await fetch(upload.url, { method: 'PUT', body: readStream });
 
 // The upload may not be updated immediately, but shortly after the upload is finished you'll get a `video.asset.created` event and the upload will now have a status of `asset_created` and a new `asset_id` key.
 let updatedUpload = await Video.Uploads.get(upload.id);


### PR DESCRIPTION
# Description

Update the docs given friction encountered following examples in the README

1. Replace usage of `request` with another request library in our example. Users can use whatever they prefer ➕ 
2. Explicitly require packages like `fs` and `dotenv` ➕ 
3. Make playback ID available to the consumer in one step instead of two ➕ 

There's no strong preference for CJS vs ESM. So I've kept the `require`s as is.

## Possible Future Improvement(s)
Consider an `uploadFile` function on the Mux object to save consumers the headache of finding a request library that works well in node for them. Requires more testing and error handling. For now, we're on a time crunch to release the typescript conversion branch which this doc improvement should ideally release with ⏲️ 

## Note

This is a [cleaned up version of this PR](https://github.com/muxinc/docs.mux.com/pull/460).