### PR TITLE
esmodule fix + test updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@ Releases are primarily tracked in the Github [Releases panel](https://github.com
 # 5.0.0
 
 - mux-node-sdk is now TypeScript-native! 🎉
-- the top-level `Mux` class has now changed to a commonjs default export. This may break your imports, but should be a quick fix.
+- exports are now ESModule exports, not CommonJS exports; this means that, if you are using CJS `require`s, you will need to update to `require('@mux/mux-node').default`. The same holds true for direct imports from other files within `@mux/mux-node`'s structure.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-const Library = require('./mux');
+import { Mux } from './mux';
 
-// because we have old clients who are using this, we will still need
-// to use old-style exports at the module edge.
-module.exports = Library.Mux;
+export default Mux;

--- a/test/integration/data/errors.spec.js
+++ b/test/integration/data/errors.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {Errors} */
 describe('Integration::Errors', () => {

--- a/test/integration/data/exports.spec.js
+++ b/test/integration/data/exports.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {Exports} */
 describe('Integration::Exports', () => {

--- a/test/integration/data/filters.spec.js
+++ b/test/integration/data/filters.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {Filters} */
 describe('Integration::Filters', () => {

--- a/test/integration/data/incidents.spec.js
+++ b/test/integration/data/incidents.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {Incidents} */
 describe('Integration::Incidents', () => {

--- a/test/integration/data/metrics.spec.js
+++ b/test/integration/data/metrics.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {Metrics} */
 describe('Integration::Metrics', () => {

--- a/test/integration/data/real_time.spec.js
+++ b/test/integration/data/real_time.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {RealTime} */
 describe('Integration::RealTime', () => {

--- a/test/integration/data/video_views.spec.js
+++ b/test/integration/data/video_views.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {VideoViews} */
 describe('Integration::VideoViews', () => {

--- a/test/integration/video/assets.spec.js
+++ b/test/integration/video/assets.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 const TEST_VIDEO =
   'https://storage.googleapis.com/muxdemofiles/mux-video-intro.mp4';

--- a/test/integration/video/deliveryUsage.spec.js
+++ b/test/integration/video/deliveryUsage.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {DeliveryUsage} */
 describe('Integration::DeliveryUsage', () => {

--- a/test/integration/video/liveStreams.spec.js
+++ b/test/integration/video/liveStreams.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {LiveStreams} */
 describe('Integration::LiveStreams', () => {

--- a/test/integration/video/playbackIds.spec.js
+++ b/test/integration/video/playbackIds.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 const TEST_VIDEO =
   'https://storage.googleapis.com/muxdemofiles/mux-video-intro.mp4';

--- a/test/integration/video/signingKeys.spec.js
+++ b/test/integration/video/signingKeys.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {SigningKeys} */
 describe('Integration:SigningKeys', () => {

--- a/test/integration/video/uploads.spec.js
+++ b/test/integration/video/uploads.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const nockBack = require('nock').back;
-const Mux = require('../../../dist');
+const Mux = require('../../../dist').default;
 
 /** @test {Uploads} */
 describe('Integration::Uploads', () => {


### PR DESCRIPTION
Instead of trying to split the difference with a CJS main export, we need to bite the bullet and make it an ESModule export (or else typescript in consuming projects gets _very_ confused).