### PR TITLE
Add `source_asset_id` property to Asset interface

### DIFF
--- a/src/video/domain.ts
+++ b/src/video/domain.ts
@@ -127,6 +127,7 @@ export interface Asset {
   aspect_ratio?: string;
   per_title_encode?: boolean;
   is_live?: boolean;
+  source_asset_id?: string;
   playback_ids?: Array<PlaybackId>;
   tracks?: Array<Track>;
   mp4_support: AssetMp4Support;


### PR DESCRIPTION
I noticed that, when an asset is created starting from another asset (e.g. when one generates clips), a `source_asset_id` property is present. This PR adds that property to the `Asset` interface.

<img width="559" alt="image" src="https://user-images.githubusercontent.com/21128334/163045865-eb5d7762-5b2f-4322-9f80-75b602009ebb.png">
