### PR TITLE
fix(jwt): correct typing for type in MuxJWTSignOptions

### DIFF
--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -17,7 +17,7 @@ export interface MuxJWTSignOptions {
   keyId?: string;
   keySecret?: string;
   keyFilePath?: string;
-  type?: TypeClaim;
+  type?: string;
   expiration?: string;
   params?: Record<string, string>;
 }


### PR DESCRIPTION
Previously, `type` in the `MuxJWTSignOptions` interface was set as a
`TypeClaim`. However, wherever this is used, it is expected to be a string and
is mapped to a `TypeClaim`. This is most evident on line 94, where type is
defaulted to `'video'`, not a `TypeClaim`.