### PR TITLE
Add custom header for platform identification

### DIFF
--- a/src/RequestOptions.ts
+++ b/src/RequestOptions.ts
@@ -1,7 +1,21 @@
 export interface RequestOptions {
   baseUrl?: string;
+  platform?: {
+    name?: string;
+    version?: string;
+  };
   auth?: {
     username?: string;
     password?: string;
+  };
+}
+
+export interface RequestParams {
+  baseURL?: string | undefined;
+  headers?: any;
+  withCredentials?: boolean;
+  auth?: {
+    username: string;
+    password: string;
   };
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -3,7 +3,7 @@
 import Axios, { AxiosInstance } from 'axios';
 import EventEmitter from 'events';
 
-import { RequestOptions } from './RequestOptions.js';
+import { RequestOptions, RequestParams } from './RequestOptions.js';
 import { VERSION } from './version.js';
 
 /**
@@ -58,7 +58,7 @@ export class Base extends EventEmitter {
         this.config = config ?? {};
       }
 
-      this.http = Axios.create({
+      const request: RequestParams = {
         baseURL: this.config.baseUrl,
         headers: {
           'User-Agent': `Mux Node | ${VERSION}`,
@@ -70,7 +70,15 @@ export class Base extends EventEmitter {
           username: this._tokenId,
           password: this._tokenSecret,
         },
-      });
+      };
+
+      if (this.config.platform?.name) {
+        request.headers[
+          'x-source-platform'
+        ] = `${this.config.platform?.name} | ${this.config.platform?.version}`;
+      }
+
+      this.http = Axios.create(request);
 
       this.http.interceptors.request.use((req: any) => {
         this.emit('request', req);

--- a/src/base.ts
+++ b/src/base.ts
@@ -73,6 +73,14 @@ export class Base extends EventEmitter {
       };
 
       if (this.config.platform?.name) {
+        if (this.config.platform?.name?.includes('|')) {
+          throw new Error('Platform name cannot contain a "|" value.');
+        }
+
+        if (this.config.platform?.version?.includes('|')) {
+          throw new Error('Platform version cannot contain a "|" value.');
+        }
+
         request.headers[
           'x-source-platform'
         ] = `${this.config.platform?.name} | ${this.config.platform?.version}`;

--- a/test/unit/base.spec.cjs
+++ b/test/unit/base.spec.cjs
@@ -36,6 +36,74 @@ describe('Unit::Base', () => {
       expect(childBase.tokenSecret).to.be.eq(parentBase.tokenSecret);
     });
 
+    it('allows the source platform header to be defined', () => {
+      const name = 'Some cool platform';
+      const version = '1.0.0';
+      const options = {
+        platform: {
+          name,
+          version
+        }
+      };
+      const baseClient = new Base(options);
+      const headers = baseClient.http.defaults.headers;
+      const sourcePlatformHeader = headers['x-source-platform'];
+      expect(sourcePlatformHeader).to.not.be.undefined;
+      expect(sourcePlatformHeader).to.equal(`${name} | ${version}`);
+    });
+
+    it('validates that the source platform header does not have a pipe character in the name', () => {
+      const name = 'Some | cool | platform';
+      const version = '1.0.0';
+      const options = {
+        platform: {
+          name,
+          version
+        }
+      };
+      const proxy = (options) => new Base(options);
+      const baseClientBound = proxy.bind(this, options);
+      expect(baseClientBound).to.throw('Platform name cannot contain a "|" value.');
+    });
+
+    it('validates that the source platform header does not have a pipe character in the version', () => {
+      const name = 'Some cool platform';
+      const version = '1.0.0 | beta';
+      const options = {
+        platform: {
+          name,
+          version
+        }
+      };
+      const proxy = (options) => new Base(options);
+      const baseClientBound = proxy.bind(this, options);
+      expect(baseClientBound).to.throw('Platform version cannot contain a "|" value.');
+    });
+
+    it('allows the source platform header to have a name and not a version', () => {
+      const name = 'Some cool platform';
+      const options = {
+        platform: { name }
+      };
+      const baseClient = new Base(options);
+      const headers = baseClient.http.defaults.headers;
+      const sourcePlatformHeader = headers['x-source-platform'];
+      expect(sourcePlatformHeader).to.not.be.null;
+      expect(sourcePlatformHeader).to.not.be.undefined;
+      expect(sourcePlatformHeader).to.equal(`${name} | undefined`);
+    });
+
+    it('ignore the source platform header setting if no name is provided', () => {
+      const version = '1.0.0';
+      const options = {
+        platform: { version }
+      };
+      const baseClient = new Base(options);
+      const headers = baseClient.http.defaults.headers;
+      const sourcePlatformHeader = headers['x-source-platform'];
+      expect(sourcePlatformHeader).to.be.undefined;
+    });
+
     describe('http requests', () => {
       let baseClient;
 


### PR DESCRIPTION
Adds an optional custom header that users can add to aid in identifying the platform being used to make the request.
```
new Mux(accessToken, secret, { 
   platform {
     name : 'My Platform',
     version '2.0'
   }
});
```