### PR TITLE
Make embedded_subtitles optional

### DIFF
--- a/src/video/domain.ts
+++ b/src/video/domain.ts
@@ -306,7 +306,7 @@ export interface CreateLiveStreamParams {
   test?: boolean;
   audio_only?: boolean;
   max_continuous_duration?: number;
-  embedded_subtitles: Array<LiveStreamEmbeddedSubtitleSettings>;
+  embedded_subtitles?: Array<LiveStreamEmbeddedSubtitleSettings>;
   use_slate_for_standard_latency?: boolean;
   reconnect_slate_url?: string;
 }


### PR DESCRIPTION
`embedded_subtitles` should be an optional type when creating a livestream:
<img width="809" alt="Screen Shot 2022-10-14 at 12 53 33 PM" src="https://user-images.githubusercontent.com/5719269/195905219-d0e81358-1dfc-420a-a1b3-ac0af860252b.png">
