### PR TITLE
Fix incorrect types and split JWT signing

### DIFF
--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -89,7 +89,7 @@ export class JWT {
    * const token = Mux.JWT.sign('some-playback-id', { keyId: 'your key id', keySecret: 'your key secret' });
    * // Now you can use the token in a url: `https://stream.mux.com/some-playback-id.m3u8?token=${token}`
    */
-  static sign(playbackId: string, options: MuxJWTSignOptions = {}) {
+  static signPlaybackId(playbackId: string, options: MuxJWTSignOptions = {}) {
     const opts = {
       type: 'video',
       expiration: '7d',
@@ -111,6 +111,48 @@ export class JWT {
       keyid: keyId,
       subject: playbackId,
       audience: typeClaim,
+      expiresIn: opts.expiration,
+      noTimestamp: true,
+      algorithm: 'RS256',
+    };
+
+    return jwt.sign(opts.params, keySecret, tokenOptions);
+  }
+  /**
+   * Creates a new token to be used with a signed Space ID
+   * @param {string} spaceId - The Space ID (of type 'signed') that you'd like to generate a token for.
+   * @param {Object} options - Configuration options to use when creating the token
+   * @param {string} [options.keyId] - The signing key ID to use. If not specified, process.env.MUX_SIGNING_KEY is attempted
+   * @param {string} [options.keySecret] - The signing key secret. If not specified, process.env.MUX_PRIVATE_KEY is used.
+   * @param {string} [options.type=rt] - Type of token this will be. Which is rt for Real-time
+   * @param {string} [options.expiration=7d] - Length of time for the token to be valid.
+   * @param {Object} [options.params] - Any additional query params you'd use with a public url.
+   * @returns {string} - Returns a token to be used with a signed URL.
+   *
+   * @example
+   * const Mux = require('@mux/mux-node');
+   *
+   * const token = Mux.JWT.signSpaceId('some-space-id', { keyId: 'your key id', keySecret: 'your key secret' });
+   */
+  static signSpaceId(spaceId: string, options: MuxJWTSignOptions = {}) {
+    const opts = {
+      type: 'rt',
+      expiration: '7d',
+      params: {},
+      ...options,
+    };
+
+    const keyId = getSigningKey(options);
+    const keySecret = getPrivateKey(options);
+
+    if (opts.type !== 'rt') {
+      throw new Error(`Invalid signature type: ${opts.type}`);
+    }
+
+    const tokenOptions: jwt.SignOptions = {
+      keyid: keyId,
+      subject: spaceId,
+      audience: opts.type,
       expiresIn: opts.expiration,
       noTimestamp: true,
       algorithm: 'RS256',

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -88,6 +88,32 @@ export class JWT {
    *
    * const token = Mux.JWT.sign('some-playback-id', { keyId: 'your key id', keySecret: 'your key secret' });
    * // Now you can use the token in a url: `https://stream.mux.com/some-playback-id.m3u8?token=${token}`
+   *
+   * @deprecated This method should not be used, you should use signPlaybackId instead
+   */
+  static sign(playbackId: string, options: MuxJWTSignOptions = {}) {
+    process.emitWarning(
+      'The JWT.sign() method has been deprecated, please use JWT.signPlaybackId() instead',
+      'DeprecatedWarning'
+    );
+    return this.signPlaybackId(playbackId, options);
+  }
+  /**
+   * Creates a new token to be used with a signed playback ID
+   * @param {string} playbackId - The Playback ID (of type 'signed') that you'd like to generate a token for.
+   * @param {Object} options - Configuration options to use when creating the token
+   * @param {string} [options.keyId] - The signing key ID to use. If not specified, process.env.MUX_SIGNING_KEY is attempted
+   * @param {string} [options.keySecret] - The signing key secret. If not specified, process.env.MUX_PRIVATE_KEY is used.
+   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, or `storyboard`
+   * @param {string} [options.expiration=7d] - Length of time for the token to be valid.
+   * @param {Object} [options.params] - Any additional query params you'd use with a public url. For example, with a thumbnail this would be values such as `time`.
+   * @returns {string} - Returns a token to be used with a signed URL.
+   *
+   * @example
+   * const Mux = require('@mux/mux-node');
+   *
+   * const token = Mux.JWT.sign('some-playback-id', { keyId: 'your key id', keySecret: 'your key secret' });
+   * // Now you can use the token in a url: `https://stream.mux.com/some-playback-id.m3u8?token=${token}`
    */
   static signPlaybackId(playbackId: string, options: MuxJWTSignOptions = {}) {
     const opts = {
@@ -124,7 +150,6 @@ export class JWT {
    * @param {Object} options - Configuration options to use when creating the token
    * @param {string} [options.keyId] - The signing key ID to use. If not specified, process.env.MUX_SIGNING_KEY is attempted
    * @param {string} [options.keySecret] - The signing key secret. If not specified, process.env.MUX_PRIVATE_KEY is used.
-   * @param {string} [options.type=rt] - Type of token this will be. Which is rt for Real-time
    * @param {string} [options.expiration=7d] - Length of time for the token to be valid.
    * @param {Object} [options.params] - Any additional query params you'd use with a public url.
    * @returns {string} - Returns a token to be used with a signed URL.
@@ -136,7 +161,6 @@ export class JWT {
    */
   static signSpaceId(spaceId: string, options: MuxJWTSignOptions = {}) {
     const opts = {
-      type: 'rt',
       expiration: '7d',
       params: {},
       ...options,
@@ -145,14 +169,10 @@ export class JWT {
     const keyId = getSigningKey(options);
     const keySecret = getPrivateKey(options);
 
-    if (opts.type !== 'rt') {
-      throw new Error(`Invalid signature type: ${opts.type}`);
-    }
-
     const tokenOptions: jwt.SignOptions = {
       keyid: keyId,
       subject: spaceId,
-      audience: opts.type,
+      audience: 'rt',
       expiresIn: opts.expiration,
       noTimestamp: true,
       algorithm: 'RS256',

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -12,6 +12,7 @@ export enum TypeClaim {
   thumbnail = 't',
   gif = 'g',
   storyboard = 's',
+  stats = 'playback_id',
 }
 export interface MuxJWTSignOptions {
   keyId?: string;
@@ -78,7 +79,7 @@ export class JWT {
    * @param {Object} options - Configuration options to use when creating the token
    * @param {string} [options.keyId] - The signing key ID to use. If not specified, process.env.MUX_SIGNING_KEY is attempted
    * @param {string} [options.keySecret] - The signing key secret. If not specified, process.env.MUX_PRIVATE_KEY is used.
-   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, or `storyboard`
+   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, `storyboard` or `stats`
    * @param {string} [options.expiration=7d] - Length of time for the token to be valid.
    * @param {Object} [options.params] - Any additional query params you'd use with a public url. For example, with a thumbnail this would be values such as `time`.
    * @returns {string} - Returns a token to be used with a signed URL.
@@ -104,7 +105,7 @@ export class JWT {
    * @param {Object} options - Configuration options to use when creating the token
    * @param {string} [options.keyId] - The signing key ID to use. If not specified, process.env.MUX_SIGNING_KEY is attempted
    * @param {string} [options.keySecret] - The signing key secret. If not specified, process.env.MUX_PRIVATE_KEY is used.
-   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, or `storyboard`
+   * @param {string} [options.type=video] - Type of token this will be. Valid types are `video`, `thumbnail`, `gif`, `storyboard` or `stats`
    * @param {string} [options.expiration=7d] - Length of time for the token to be valid.
    * @param {Object} [options.params] - Any additional query params you'd use with a public url. For example, with a thumbnail this would be values such as `time`.
    * @returns {string} - Returns a token to be used with a signed URL.

--- a/src/video/domain.ts
+++ b/src/video/domain.ts
@@ -357,14 +357,6 @@ export interface ListUploadParams {
   upload_id?: string;
 }
 
-export interface GetAssetPlaybackIdResponse {
-  data: PlaybackId;
-}
-
-export interface GetLiveStreamPlaybackIdResponse {
-  data: PlaybackId;
-}
-
 export interface ReferrerDomainRestriction {
   allowed_domains?: Array<string>;
   allow_no_referrer?: boolean;
@@ -379,14 +371,6 @@ export interface PlaybackRestriction {
   created_at: string;
   updated_at?: string;
   referrer?: ReferrerDomainRestriction;
-}
-
-export interface PlaybackRestrictionResponse {
-  data: PlaybackRestriction;
-}
-
-export interface ListPlaybackRestrictionsResponse {
-  data: Array<PlaybackRestriction>;
 }
 
 export type SpaceStatus = 'idle' | 'active';
@@ -434,29 +418,9 @@ export interface CreateSpaceRequest {
   broadcasts?: Array<CreateBroadcastRequest>;
 }
 
-export interface SpaceResponse {
-  data: Space;
-}
-
-export interface BroadcastResponse {
-  data: Broadcast;
-}
-
 export interface ListSpacesRequest {
   limit?: number;
   page?: number;
-}
-
-export interface ListSpacesResponse {
-  data: Array<Space>;
-}
-
-export interface StartSpaceBroadcastResponse {
-  data: {};
-}
-
-export interface StopSpaceBroadcastResponse {
-  data: {};
 }
 
 export interface TranscriptionVocabulary {
@@ -471,12 +435,4 @@ export interface UpsertTranscriptionVocabularyParams {
   name: string;
   phrases: string[];
   passthrough?: string;
-}
-
-export interface ListTranscriptionVocabulariesResponse {
-  data: Array<TranscriptionVocabulary>;
-}
-
-export interface TranscriptionVocabularyResponse {
-  data: TranscriptionVocabulary;
 }

--- a/src/video/resources/playbackRestrictions.ts
+++ b/src/video/resources/playbackRestrictions.ts
@@ -1,8 +1,7 @@
 import { Base } from '../../base.js';
 import {
   CreatePlaybackRestrictionParams,
-  ListPlaybackRestrictionsResponse,
-  PlaybackRestrictionResponse,
+  PlaybackRestriction,
   ReferrerDomainRestriction,
 } from '../domain.js';
 
@@ -20,26 +19,26 @@ const buildBasePath = (restrictionId: string) => `${PATH}/${restrictionId}`;
 export class PlaybackRestrictions extends Base {
   create(
     restriction: CreatePlaybackRestrictionParams
-  ): Promise<PlaybackRestrictionResponse> {
+  ): Promise<PlaybackRestriction> {
     return this.http.post(PATH, restriction);
   }
 
-  list(): Promise<ListPlaybackRestrictionsResponse> {
+  list(): Promise<Array<PlaybackRestriction>> {
     return this.http.get(PATH);
   }
 
-  get(restrictionId: string): Promise<PlaybackRestrictionResponse> {
+  get(restrictionId: string): Promise<PlaybackRestriction> {
     return this.http.get(buildBasePath(restrictionId));
   }
 
-  delete(restrictionId: string): Promise<PlaybackRestrictionResponse> {
+  delete(restrictionId: string): Promise<PlaybackRestriction> {
     return this.http.delete(buildBasePath(restrictionId));
   }
 
   putReferrer(
     restrictionId: string,
     referrer: ReferrerDomainRestriction
-  ): Promise<PlaybackRestrictionResponse> {
+  ): Promise<PlaybackRestriction> {
     return this.http.put(`${buildBasePath(restrictionId)}/referrer`, referrer);
   }
 }

--- a/src/video/resources/spaces.ts
+++ b/src/video/resources/spaces.ts
@@ -23,7 +23,7 @@ export class Broadcasts extends Base {
     return this.http.get(BROADCAST_PATH(spaceId, broadcastId));
   }
 
-  delete(spaceId: string, broadcastId: string): Promise<Broadcast> {
+  delete(spaceId: string, broadcastId: string): Promise<any> {
     return this.http.delete(BROADCAST_PATH(spaceId, broadcastId));
   }
 

--- a/src/video/resources/spaces.ts
+++ b/src/video/resources/spaces.ts
@@ -1,14 +1,11 @@
 import { Base } from '../../base.js';
 import { RequestOptions } from '../../RequestOptions.js';
 import {
-  BroadcastResponse,
+  Broadcast,
   CreateBroadcastRequest,
   CreateSpaceRequest,
   ListSpacesRequest,
-  ListSpacesResponse,
-  SpaceResponse,
-  StartSpaceBroadcastResponse,
-  StopSpaceBroadcastResponse,
+  Space,
 } from '../domain.js';
 
 const BASE_PATH = '/video/v1/spaces';
@@ -18,32 +15,23 @@ const BROADCAST_PATH = (spaceId: string, broadcastId: string) =>
   `${SPACE_PATH(spaceId)}/broadcasts/${broadcastId}`;
 
 export class Broadcasts extends Base {
-  create(
-    spaceId: string,
-    request: CreateBroadcastRequest
-  ): Promise<BroadcastResponse> {
+  create(spaceId: string, request: CreateBroadcastRequest): Promise<Broadcast> {
     return this.http.post(`${SPACE_PATH(spaceId)}/broadcasts`, request);
   }
 
-  get(spaceId: string, broadcastId: string): Promise<BroadcastResponse> {
+  get(spaceId: string, broadcastId: string): Promise<Broadcast> {
     return this.http.get(BROADCAST_PATH(spaceId, broadcastId));
   }
 
-  delete(spaceId: string, broadcastId: string): Promise<BroadcastResponse> {
+  delete(spaceId: string, broadcastId: string): Promise<Broadcast> {
     return this.http.delete(BROADCAST_PATH(spaceId, broadcastId));
   }
 
-  start(
-    spaceId: string,
-    broadcastId: string
-  ): Promise<StartSpaceBroadcastResponse> {
+  start(spaceId: string, broadcastId: string): Promise<any> {
     return this.http.post(`${BROADCAST_PATH(spaceId, broadcastId)}/start`);
   }
 
-  stop(
-    spaceId: string,
-    broadcastId: string
-  ): Promise<StopSpaceBroadcastResponse> {
+  stop(spaceId: string, broadcastId: string): Promise<any> {
     return this.http.post(`${BROADCAST_PATH(spaceId, broadcastId)}/stop`);
   }
 }
@@ -71,19 +59,19 @@ export class Spaces extends Base {
     this.Broadcasts = new Broadcasts(this);
   }
 
-  create(req: CreateSpaceRequest): Promise<SpaceResponse> {
+  create(req: CreateSpaceRequest): Promise<Space> {
     return this.http.post(BASE_PATH, req);
   }
 
-  list(params: ListSpacesRequest): Promise<ListSpacesResponse> {
+  list(params: ListSpacesRequest): Promise<Array<Space>> {
     return this.http.get(BASE_PATH, { params });
   }
 
-  get(spaceId: string): Promise<SpaceResponse> {
+  get(spaceId: string): Promise<Space> {
     return this.http.get(SPACE_PATH(spaceId));
   }
 
-  delete(spaceId: string): Promise<SpaceResponse> {
+  delete(spaceId: string): Promise<Space> {
     return this.http.delete(SPACE_PATH(spaceId));
   }
 }

--- a/src/video/resources/transcriptionVocabularies.ts
+++ b/src/video/resources/transcriptionVocabularies.ts
@@ -1,8 +1,7 @@
 import { Base } from '../../base.js';
 import {
   UpsertTranscriptionVocabularyParams,
-  ListTranscriptionVocabulariesResponse,
-  TranscriptionVocabularyResponse,
+  TranscriptionVocabulary,
 } from '../domain.js';
 
 /**
@@ -20,17 +19,15 @@ const buildBasePath = (transcriptionVocabularyId: string) =>
 export class TranscriptionVocabularies extends Base {
   create(
     transcriptionVocabulary: UpsertTranscriptionVocabularyParams
-  ): Promise<TranscriptionVocabularyResponse> {
+  ): Promise<TranscriptionVocabulary> {
     return this.http.post(PATH, transcriptionVocabulary);
   }
 
-  list(): Promise<ListTranscriptionVocabulariesResponse> {
+  list(): Promise<Array<TranscriptionVocabulary>> {
     return this.http.get(PATH);
   }
 
-  get(
-    transcriptionVocabularyId: string
-  ): Promise<TranscriptionVocabularyResponse> {
+  get(transcriptionVocabularyId: string): Promise<TranscriptionVocabulary> {
     return this.http.get(buildBasePath(transcriptionVocabularyId));
   }
 
@@ -41,7 +38,7 @@ export class TranscriptionVocabularies extends Base {
   update(
     transcriptionVocabularyId: string,
     transcriptionVocabulary: UpsertTranscriptionVocabularyParams
-  ): Promise<TranscriptionVocabularyResponse> {
+  ): Promise<TranscriptionVocabulary> {
     return this.http.put(
       `${buildBasePath(transcriptionVocabularyId)}`,
       transcriptionVocabulary

--- a/test/unit/mux.spec.cjs
+++ b/test/unit/mux.spec.cjs
@@ -20,7 +20,7 @@ describe('Unit::Mux', () => {
 
     /** @test {Mux.JTW} */
     it('exposes JWT Helper utilities as static methods', () => {
-      expect(Mux.JWT.sign).to.be.a('function');
+      expect(Mux.JWT.signPlaybackId).to.be.a('function');
       expect(Mux.JWT.decode).to.be.a('function');
     });
 

--- a/test/unit/mux.spec.cjs
+++ b/test/unit/mux.spec.cjs
@@ -21,6 +21,7 @@ describe('Unit::Mux', () => {
     /** @test {Mux.JTW} */
     it('exposes JWT Helper utilities as static methods', () => {
       expect(Mux.JWT.signPlaybackId).to.be.a('function');
+      expect(Mux.JWT.signSpaceId).to.be.a('function');
       expect(Mux.JWT.decode).to.be.a('function');
     });
 

--- a/test/unit/utils/jwt.spec.cjs
+++ b/test/unit/utils/jwt.spec.cjs
@@ -8,16 +8,16 @@ const TEST_SECRET =
 
 /** @test {Mux.Utils.JWT} */
 describe('Utils::JWT', () => {
-  /** @test {Mux.Utils.JWT.sign} */
+  /** @test {Mux.Utils.JWT.signPlaybackId} */
   describe('sign', () => {
-    /** @test {Mux.Utils.JWT.sign} */
+    /** @test {Mux.Utils.JWT.signPlaybackId} */
     it('defaults to video and includes an expiration', () => {
       const options = {
         keyId: TEST_ID,
         keySecret: TEST_SECRET,
       };
 
-      const token = JWT.sign('some-playback-id', options);
+      const token = JWT.signPlaybackId('some-playback-id', options);
       expect(token).to.be.a('string');
       const decoded = JWT.decode(token);
       expect(decoded.aud).to.eq('v');
@@ -30,7 +30,7 @@ describe('Utils::JWT', () => {
         keySecret: TEST_SECRET,
         type: 'video',
       };
-      const token = JWT.sign('some-playback-id', options);
+      const token = JWT.signPlaybackId('some-playback-id', options);
       expect(token).to.be.a('string');
       const decoded = JWT.decode(token);
       expect(decoded.aud).to.eq('v');
@@ -42,7 +42,7 @@ describe('Utils::JWT', () => {
         keySecret: TEST_SECRET,
         type: 'thumbnail',
       };
-      const token = JWT.sign('some-playback-id', options);
+      const token = JWT.signPlaybackId('some-playback-id', options);
       expect(token).to.be.a('string');
       const decoded = JWT.decode(token);
       expect(decoded.aud).to.eq('t');
@@ -54,7 +54,7 @@ describe('Utils::JWT', () => {
         keySecret: TEST_SECRET,
         type: 'gif',
       };
-      const token = JWT.sign('some-playback-id', options);
+      const token = JWT.signPlaybackId('some-playback-id', options);
       expect(token).to.be.a('string');
       const decoded = JWT.decode(token);
       expect(decoded.aud).to.eq('g');
@@ -66,7 +66,7 @@ describe('Utils::JWT', () => {
         keySecret: TEST_SECRET,
         type: 'storyboard',
       };
-      const token = JWT.sign('some-playback-id', options);
+      const token = JWT.signPlaybackId('some-playback-id', options);
       expect(token).to.be.a('string');
       const decoded = JWT.decode(token);
       expect(decoded.aud).to.eq('s');
@@ -79,7 +79,7 @@ describe('Utils::JWT', () => {
         type: 'gif',
       };
 
-      const token = JWT.sign('some-playback-id', options);
+      const token = JWT.signPlaybackId('some-playback-id', options);
       expect(token).to.be.a('string');
       const decoded = JWT.decode(token);
       expect(decoded.aud).to.eq('g');
@@ -92,7 +92,7 @@ describe('Utils::JWT', () => {
         type: 'gif',
       };
 
-      const token = JWT.sign('some-playback-id', options);
+      const token = JWT.signPlaybackId('some-playback-id', options);
       expect(token).to.be.a('string');
       const decoded = JWT.decode(token);
       expect(decoded.aud).to.eq('g');
@@ -110,8 +110,8 @@ describe('Utils::JWT', () => {
         expiration: 60 * 60 * 3,
       };
 
-      const token1 = JWT.sign('some-playback-id', options1);
-      const token2 = JWT.sign('some-playback-id', options2);
+      const token1 = JWT.signPlaybackId('some-playback-id', options1);
+      const token2 = JWT.signPlaybackId('some-playback-id', options2);
       expect(token1).to.be.a('string');
       expect(token2).to.be.a('string');
 

--- a/test/unit/utils/jwt.spec.cjs
+++ b/test/unit/utils/jwt.spec.cjs
@@ -9,7 +9,7 @@ const TEST_SECRET =
 /** @test {Mux.Utils.JWT} */
 describe('Utils::JWT', () => {
   /** @test {Mux.Utils.JWT.signPlaybackId} */
-  describe('sign', () => {
+  describe('signPlaybackId', () => {
     /** @test {Mux.Utils.JWT.signPlaybackId} */
     it('defaults to video and includes an expiration', () => {
       const options = {
@@ -112,6 +112,70 @@ describe('Utils::JWT', () => {
 
       const token1 = JWT.signPlaybackId('some-playback-id', options1);
       const token2 = JWT.signPlaybackId('some-playback-id', options2);
+      expect(token1).to.be.a('string');
+      expect(token2).to.be.a('string');
+
+      const decoded1 = JWT.decode(token1);
+      const decoded2 = JWT.decode(token2);
+      expect(decoded1.exp).to.be.closeTo(decoded2.exp, 2);
+    });
+  });
+  /** @test {Mux.Utils.JWT.signSpaceId} */
+  describe('signSpaceId', () => {
+    /** @test {Mux.Utils.JWT.signPlaybackId} */
+    it('defaults to rt and includes an expiration', () => {
+      const options = {
+        keyId: TEST_ID,
+        keySecret: TEST_SECRET,
+      };
+
+      const token = JWT.signSpaceId('some-space-id', options);
+      expect(token).to.be.a('string');
+      const decoded = JWT.decode(token);
+      expect(decoded.aud).to.eq('rt');
+      expect(decoded.exp).to.be.greaterThan(new Date().getTime() / 1000);
+    });
+
+    it('takes a file path for a secret', () => {
+      const options = {
+        keyId: TEST_ID,
+        keyFilePath: path.join(__dirname, 'example-private-key.pem'),
+        type: 'rt',
+      };
+
+      const token = JWT.signSpaceId('some-space-id', options);
+      expect(token).to.be.a('string');
+      const decoded = JWT.decode(token);
+      expect(decoded.aud).to.eq('rt');
+    });
+
+    it('falls back to using environment variables for the key and secret', () => {
+      process.env.MUX_SIGNING_KEY = TEST_ID;
+      process.env.MUX_PRIVATE_KEY = TEST_SECRET;
+      const options = {
+        type: 'rt',
+      };
+
+      const token = JWT.signSpaceId('some-space-id', options);
+      expect(token).to.be.a('string');
+      const decoded = JWT.decode(token);
+      expect(decoded.aud).to.eq('rt');
+    });
+
+    it('accepts a timestamp or time shorthand', () => {
+      const options1 = {
+        keyId: TEST_ID,
+        keySecret: TEST_SECRET,
+        expiration: '3h',
+      };
+
+      const options2 = {
+        ...options1,
+        expiration: 60 * 60 * 3,
+      };
+
+      const token1 = JWT.signSpaceId('some-space-id', options1);
+      const token2 = JWT.signSpaceId('some-space-id', options2);
       expect(token1).to.be.a('string');
       expect(token2).to.be.a('string');
 


### PR DESCRIPTION
This PR addresses https://github.com/muxinc/mux-node-sdk/issues/197 as well as https://github.com/muxinc/mux-node-sdk/pull/194

It fixes the following types:
```
GetAssetPlaybackIdResponse
GetLiveStreamPlaybackIdResponse
PlaybackRestrictionResponse
ListPlaybackRestrictionsResponse
SpaceResponse
BroadcastResponse
ListSpacesResponse 
StartSpaceBroadcastResponse
StopSpaceBroadcastResponse
ListTranscriptionVocabulariesResponse
TranscriptionVocabularyResponse
```

and splits JWT signing into playback Ids and Space Ids for Real Time