### PR TITLE
Add additional types declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "author": "Mux <help@mux.com> (https://mux.com/)",
   "main": "./dist/mux.js",
+  "types": "./dist/mux.d.ts",
   "exports": {
     "import": "./dist/mux.mjs",
     "require": "./dist/mux.js",


### PR DESCRIPTION
[TS5 and `--moduleResolution bundler`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler) require us to be a little more explicit with our types.

First realized this after [`create-next-app` changed its default `moduleResolution` to `bundler`](https://github.com/vercel/next.js/pull/51957)

<img width="400" alt="CleanShot 2023-07-27 at 11 56 23@2x" src="https://github.com/muxinc/mux-node-sdk/assets/8933386/2377e203-b892-44bd-820a-810955cae52f">

The changes in this PR have been tested using `yarn link` against that `create-next-app` repo. VSCode integrations and ts build errors are back!
<img width="400" alt="CleanShot 2023-07-27 at 11 58 35@2x" src="https://github.com/muxinc/mux-node-sdk/assets/8933386/01fda736-1fe7-43f3-8008-302b0eed6b98">
<img width="400" alt="CleanShot 2023-07-27 at 11 59 38@2x" src="https://github.com/muxinc/mux-node-sdk/assets/8933386/7df1b020-aca8-412f-ad19-224c909a3154">
