### PR TITLE
add background to broadcast resquest

### DIFF
--- a/src/video/domain.ts
+++ b/src/video/domain.ts
@@ -411,6 +411,7 @@ export interface CreateBroadcastRequest {
   passthrough?: string;
   layout?: BroadcastLayout;
   resolution?: BroadcastResolution;
+  background?: string;
 }
 
 export interface CreateSpaceRequest {


### PR DESCRIPTION
From the doc it is allowed to put the background URL to the broadcast https://docs.mux.com/api-reference#video/operation/create-space-broadcast