### PR TITLE
chore: don't install the beta channel in readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ In February 2024 this SDK was updated to Version 8.0. For upgrading to 8.x see [
 ## Installation
 
 ```sh
-npm install --save @mux/mux-node@beta
+npm install --save @mux/mux-node
 # or
-yarn add @mux/mux-node@beta
+yarn add @mux/mux-node
 ```
 
 ## Usage


### PR DESCRIPTION
This shouldn't be needed since the 8.0.0 release