### PR TITLE
Add latest to MCP instructions

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -14,7 +14,7 @@ For clients with a configuration JSON, it might look something like this:
   "mcpServers": {
     "mux": {
       "command": "npx",
-      "args": ["-y", "@mux/mcp", "--client=claude", "--tools=dynamic"],
+      "args": ["-y", "@mux/mcp@latest", "--client=claude", "--tools=dynamic"],
       "env": {
         "MUX_TOKEN_ID": "my token id",
         "MUX_TOKEN_SECRET": "my secret",


### PR DESCRIPTION
Otherwise `npx` will use the cached version until the user explicitly clears their cache. 